### PR TITLE
Add support for NID database folders

### DIFF
--- a/src/main/java/vitaloaderredux/analyzer/NIDAnalyzer.java
+++ b/src/main/java/vitaloaderredux/analyzer/NIDAnalyzer.java
@@ -55,6 +55,12 @@ public class NIDAnalyzer extends AbstractAnalyzer {
 	static private final String DELETE_OLD_OPTION_DESCRIPTION =
 			"If enabled, clears all names for imports and exports before analysis";
 
+	static private final boolean DISPLAY_DB_FILENAMES_DEFAULT = false;
+	static private final String DISPLAY_DB_FILENAMES_NAME = "Log name of database files";
+	static private final String DISPLAY_DB_FILENAMES_DESCRIPTION =
+			"If enabled, the name of all NID database files loaded is logged and displayed after analysis. "
+			+ "(This option has an effect only if a NID database folder is selected)";
+
 	//Name of the environement variable that holds path to NID database
 	static private final String ENV_DATABASE_PATH_VARIABLE_NAME = "VLR_DATABASE_PATH";
 
@@ -66,7 +72,7 @@ public class NIDAnalyzer extends AbstractAnalyzer {
 	static { //Set environement source as default if available
 		if (ENVIRONMENT_DATABASE_PATH != null) {
 			File envDB = new File(ENVIRONMENT_DATABASE_PATH);
-			if (envDB.exists() && envDB.isFile()) {
+			if (envDB.exists() && (envDB.isFile() || envDB.isDirectory())) {
 				DATABASE_CHOICE_DEFAULT = DatabaseSource.Environment;
 			}
 		}
@@ -84,7 +90,8 @@ public class NIDAnalyzer extends AbstractAnalyzer {
 
 	/* -------- Options --------*/
 	private DatabaseSource chosenDB = DATABASE_CHOICE_DEFAULT;
-	private boolean clearOldNames = true;
+	private boolean clearOldNames = DELETE_OLD_OPTION_DEFAULT;
+	private boolean displayAllFilenames = DISPLAY_DB_FILENAMES_DEFAULT;
 	/* ------------------------ */
 
 	public NIDAnalyzer() {
@@ -104,15 +111,18 @@ public class NIDAnalyzer extends AbstractAnalyzer {
 	@Override
 	public void registerOptions(Options options, Program program) {
 		options.registerOption(DELETE_OLD_OPTION_NAME,
-				DELETE_OLD_OPTION_DEFAULT,null, DELETE_OLD_OPTION_DESCRIPTION);
+				DELETE_OLD_OPTION_DEFAULT, null, DELETE_OLD_OPTION_DESCRIPTION);
 		options.registerOption(DATABASE_CHOICE_NAME,
 				DATABASE_CHOICE_DEFAULT, null, DATABASE_CHOICE_DESCRIPTION);
+		options.registerOption(DISPLAY_DB_FILENAMES_NAME,
+				DISPLAY_DB_FILENAMES_DEFAULT, null, DISPLAY_DB_FILENAMES_DESCRIPTION);
 	}
 
 	@Override
 	public void optionsChanged(Options options, Program program) {
 		chosenDB = options.getEnum(DATABASE_CHOICE_NAME, DATABASE_CHOICE_DEFAULT);
 		clearOldNames = options.getBoolean(DELETE_OLD_OPTION_NAME, DELETE_OLD_OPTION_DEFAULT);
+		displayAllFilenames = options.getBoolean(DISPLAY_DB_FILENAMES_NAME, DISPLAY_DB_FILENAMES_DEFAULT);
 	}
 
 	private void deleteNonSystematicNamedSymbols(Address address, String libraryName, boolean functionSymbols) {
@@ -252,7 +262,7 @@ public class NIDAnalyzer extends AbstractAnalyzer {
 
 		try {
 			if (databaseFile.isDirectory()) {
-				database.loadFromDirectory(databaseFile, false, log);
+				database.loadFromDirectory(databaseFile, displayAllFilenames, log);
 			} else {
 				database.loadFromFile(databaseFile, log);
 			}

--- a/src/main/java/vitaloaderredux/analyzer/NIDAnalyzer.java
+++ b/src/main/java/vitaloaderredux/analyzer/NIDAnalyzer.java
@@ -61,7 +61,7 @@ public class NIDAnalyzer extends AbstractAnalyzer {
 	static private final String ENVIRONMENT_DATABASE_PATH = System.getenv(ENV_DATABASE_PATH_VARIABLE_NAME);
 
 	static private DatabaseSource DATABASE_CHOICE_DEFAULT = DatabaseSource.Builtin;
-	
+
 	static { //Set environement source as default if available
 		if (ENVIRONMENT_DATABASE_PATH != null) {
 			File envDB = new File(ENVIRONMENT_DATABASE_PATH);
@@ -80,12 +80,12 @@ public class NIDAnalyzer extends AbstractAnalyzer {
 
 	private NIDDatabase database;
 	private ProgramProcessingHelper helper;
-	
+
 	/* -------- Options --------*/
 	private DatabaseSource chosenDB = DATABASE_CHOICE_DEFAULT;
 	private boolean clearOldNames = true;
 	/* ------------------------ */
-	
+
 	public NIDAnalyzer() {
 		super(ANALYZER_TITLE, ANALYZER_DESCRIPTION, AnalyzerType.BYTE_ANALYZER);
 
@@ -142,32 +142,32 @@ public class NIDAnalyzer extends AbstractAnalyzer {
 		}
 		return seenBefore;
 	}
-	
+
 	private void analyzeFunction(IEType importOrExport, String libraryName, Address funcAddr, int functionNID) {
 		final String databaseName = database.getFunctionName(libraryName, functionNID);
 		final boolean functionSeenBefore = checkAndSetKnownAddress(knownFunctionsList, funcAddr);
 		if (clearOldNames && !functionSeenBefore) {
 			deleteNonSystematicNamedSymbols(funcAddr, libraryName, true);
 		}
-		
+
 		if (databaseName != null) {
 			// Replace the current name of the function with the DB's name
 			// and add back the overwritten name as a symbol.
-			Function func = helper.funcMgr.getFunctionAt(funcAddr);			
+			Function func = helper.funcMgr.getFunctionAt(funcAddr);
 			String oldName = func.getName(false);
-			
+
 			try {
 				//Under certain circumstances, the import thunk may find itself
 				//in the External namespace, which leads to duplicates in program tree.
 				//Put the function in global namespace to prevent this from happening.
 				func.setParentNamespace(helper.program.getGlobalNamespace());
-				
+
 				func.setName(databaseName, SourceType.ANALYSIS);
 				if (importOrExport == IEType.IMPORT) {
 					//Set name for the thunk too
 					func.getThunkedFunction(true).setName(databaseName, SourceType.ANALYSIS);
 				}
-				
+
 				helper.symTbl.createLabel(funcAddr, oldName, SourceType.ANALYSIS);
 			} catch (DuplicateNameException | InvalidInputException | CircularDependencyException e) {
 				System.err.println(e);
@@ -189,7 +189,7 @@ public class NIDAnalyzer extends AbstractAnalyzer {
 			try {
 				helper.flatAPI.createLabel(varAddr, databaseName, /* Global Namespace */null, true, SourceType.ANALYSIS);
 			} catch (Exception e) {
-				
+
 			}
 		}
 	}
@@ -201,7 +201,7 @@ public class NIDAnalyzer extends AbstractAnalyzer {
 		helper = new ProgramProcessingHelper(program);
 		knownFunctionsList = new ArrayList<Long>();
 		knownVariablesList = new ArrayList<Long>();
-		
+
 		File databaseFile = null;
 		try {
 			switch (chosenDB) {
@@ -253,7 +253,7 @@ public class NIDAnalyzer extends AbstractAnalyzer {
 			log.appendException(e);
 			return false;
 		}
-		
+
 		ObjectPropertyMap<ImportExportProperty> iepMap = ArmElfPrxLoader.getImportExportPropertyMap(program);
 
 		try {

--- a/src/main/java/vitaloaderredux/arm_relocation/ArmRelocator.java
+++ b/src/main/java/vitaloaderredux/arm_relocation/ArmRelocator.java
@@ -33,36 +33,36 @@ public class ArmRelocator {
 		R_ARM_THM_MOVW_ABS_NC = 47,
 		R_ARM_THM_MOVT_ABS = 48,
 		R_ARM_RBASE = 255;
-	
+
 	private final ArmElfPrxLoaderContext ctx;
 	private final int __varImportBlockSize;
 	private final int variableSize;
 	private int curVariablesNum = 0;
 	private final int maxVariablesNum;
-	
+
 	private MemoryBlock varImportBlock = null;
 	private Address blockStartAddr;
-	
+
 	public ArmRelocator(ArmElfPrxLoaderContext context, int varImportBlockStartVA, int varImportBlockSize, int perVariableSize) throws Exception {
 		ctx = context;
 		variableSize = perVariableSize;
 		__varImportBlockSize = varImportBlockSize;
 		maxVariablesNum = varImportBlockSize / perVariableSize;
-		
+
 		blockStartAddr = ctx.getAddressInDefaultAS(varImportBlockStartVA);
 	}
-	
+
 	private void __allocBlk() throws Exception {
 		if (varImportBlock == null) {
 			varImportBlock = ctx.memory.createUninitializedBlock("VarImport", blockStartAddr, __varImportBlockSize, false);
-			
+
 			varImportBlock.setRead(true);
 			varImportBlock.setWrite(true);
 			varImportBlock.setExecute(false);
 			varImportBlock.setComment("Imported variables memory block");
 		}
 	}
-	
+
 	/**
 	 * Obtain the size (in bytes) of a Prx2 format reftable.
 	 * @param addr The address of the reftable
@@ -77,7 +77,7 @@ public class ArmRelocator {
 		}
 		return (header & 0x0FFFFFFF0) >>> 4;
 	}
-	
+
 	/**
 	 * Allocates a slot from the import variable slot.
 	 * This function creates a label with the systematic name at the slot's address
@@ -90,89 +90,89 @@ public class ArmRelocator {
 	 */
 	public Address allocateImportVariableSlot(String libraryName, int variableNID, boolean tls) throws Exception {
 		__allocBlk();
-		
+
 		if (curVariablesNum >= maxVariablesNum) {
 			throw new LoadException("Import variable block overflow");
 		}
-		
+
 		Address varAddr = blockStartAddr.add(curVariablesNum * variableSize);
 		ctx.flatAPI.createLabel(varAddr, Utils.getSystematicName(libraryName, variableNID), true);
 		ctx.addImportExportEntry(varAddr, libraryName, variableNID, IEType.IMPORT, tls ? IEKind.TLS_VARIABLE : IEKind.VARIABLE);
-		
+
 		curVariablesNum++;
-		
+
 		return varAddr;
 	}
-	
+
 	private int readInt(int va) throws MemoryAccessException {
 		return ctx.flatAPI.getInt(ctx.getAddressInDefaultAS(va));
 	}
-	
+
 	private void writeInt(int va, int val) throws MemoryAccessException {
 		final Address dst = ctx.getAddressInDefaultAS(va);
 		ctx.flatAPI.setInt(dst, val);
 	}
-	
+
 	private void apply_one_relocation(int r_type, int S, int A, int P) throws MemoryAccessException, MalformedElfException {
 		final int displacement = (A - P + S);
-		
+
 		switch (r_type) {
 		case R_ARM_ABS32:
 		case R_ARM_TARGET1: {
 			writeInt(P, S + A);
 			break;
 		}
-		
+
 		case R_ARM_REL32:
 		case R_ARM_TARGET2: {
 			writeInt(P, displacement);
 			break;
 		}
-			
+
 		case R_ARM_THM_CALL: {
 			//This is a Thumb opcode, actually make of two 16-bit parts.
 			//Due to being read as a 32-bit integer, this results in them being reversed.
 			//To read bit X of the first part (leftmost in the ARMARM), read bit (X).
 			//To read bit X of the second part (rightmost in the ARMARM), read bit (X+16).
 			int opcode = readInt(P);
-			
+
 			//Only bits 0x01FF_FFFE of the displacement are used.
 			//Shift the displacement in advance to make the rest of the logic simpler.
 			BitfieldReader displacementReader = new BitfieldReader(displacement >>> 1);
-			
+
 			int imm11 = displacementReader.consume(11);
 			if ((opcode & ((1 << 12) << 16)) == 0) { //Bit 12 of 2nd part is clear: Encoding T2 (BLX)
 				//In BLX, imm11 is actually imm10L:H where H must be 0 - otherwise, the instruction is undefined.
 				//Ensure that bit H is clear by not copying it from the displacement.
 				imm11 &= 0x7FE;
 			}
-			
+
 			final int imm10 = displacementReader.consume(10);
 			final int I1 = displacementReader.consume(1);
 			final int I2 = displacementReader.consume(1);
 			final int Sign  = displacementReader.consume(1); //Bit S in ARMARM
-			
+
 			displacementReader.assertConsumption("R_ARM_THM_CALL", 24);
-			
+
 			//I1 = NOT(J1 EOR S) --> J1 = NOT(I1) ^ S = (I1 == S)
-			//I2 = NOT(J2 EOR S) --> J2 = NOT(I2) ^ S = (I2 == 2)			
+			//I2 = NOT(J2 EOR S) --> J2 = NOT(I2) ^ S = (I2 == 2)
 			final int J1 = (I1 == Sign) ? 1 : 0;
 			final int J2 = (I2 == Sign) ? 1 : 0;
-			
+
 			opcode &= 0xD000F800;
 			opcode |= (S << 10) | imm10; //1st 16-bit part
 			opcode |= ((J1 << 13) | (J2 << 11) | imm11) << 16; //2nd 16-bit part
-			
+
 			writeInt(P, opcode);
 			break;
 		}
-			
+
 		case R_ARM_CALL:
 		case R_ARM_JUMP24: {
 			int opcode = readInt(P);
-			
+
 			if ((opcode & 0xF0000000) == 0xF) { //BL,BLX (immediate) Encoding A2 - BLX
-			
+
 				//Original ASM is an optimized equivalent of:
 				// opcode = (opcode & 0xFE7FFFFF) | (displacement & 0x3) << 23;
 				//
@@ -181,70 +181,70 @@ public class ArmRelocator {
 				//of a shift+OR pair, saving both space and time.
 				//
 				//The original C code is probably something akin to what follows.
-				
+
 				//Set the H bit of the immediate, taken from bit 1 of the displacement.
 				opcode = (opcode & 0xFEFFFFFF) | (displacement & 0x2) << 23;
 			}
 			opcode = (opcode & 0xFF000000) | (displacement >>> 2) & 0xFFFFFF;
 
-			writeInt(P, opcode);			
+			writeInt(P, opcode);
 			break;
 		}
-			
+
 		case R_ARM_PREL31: {
 			writeInt(P, displacement & 0x7FFFFFFF);
 			break;
 		}
-			
-			
+
+
 		case R_ARM_MOVW_ABS_NC: {
 			int opcode = readInt(P);
-			
+
 			final int target = (S + A);
 			final int imm12 =  target & 0xFFF;
 			final int imm4  = (target >>> 12) & 0xF;
-			
+
 			opcode &= 0xFFF0F000;
 			opcode |= (imm4 << 16) | imm12;
-			
-			writeInt(P, opcode);			
-			break;
-		}
-			
-			
-		case R_ARM_MOVT_ABS: {
-			int opcode = readInt(P);
-			
-			final int target = (S + A);
-			final int imm12 = (target >>> 16) & 0xFFF;
-			final int imm4 =  (target >>> 28) & 0xF;
-			
-			opcode &= 0xFFF0F000;
-			opcode |= (imm4 << 16) | imm12;
-			
+
 			writeInt(P, opcode);
 			break;
 		}
-		
+
+
+		case R_ARM_MOVT_ABS: {
+			int opcode = readInt(P);
+
+			final int target = (S + A);
+			final int imm12 = (target >>> 16) & 0xFFF;
+			final int imm4 =  (target >>> 28) & 0xF;
+
+			opcode &= 0xFFF0F000;
+			opcode |= (imm4 << 16) | imm12;
+
+			writeInt(P, opcode);
+			break;
+		}
+
 		case R_ARM_THM_MOVW_ABS_NC: {
 			int opcode = readInt(P);
-			
+
 			final int target = (S + A);
 			final int imm8 = target & 0xFF;
 			final int imm3 = (target >>> 8)  & 0x7;
 			final int imm1 = (target >>> 11) & 0x1;
 			final int imm4 = (target >>> 12) & 0xF;
-			
+
 			opcode &= 0x8F00FBF0;
 			opcode |= (imm8 << 16) | (imm3 << 28) | (imm1 << 10) | imm4;
-			
-			writeInt(P, opcode);			
+
+			writeInt(P, opcode);
 			break;
 		}
-			
+
 		case R_ARM_THM_MOVT_ABS: {
 			int opcode = readInt(P);
-			
+
 			final int target = (S + A);
 			final int imm8 = (target >>> 16) & 0xFF;
 			final int imm3 = (target >>> 24)  & 0x7;
@@ -253,37 +253,37 @@ public class ArmRelocator {
 
 			opcode &= 0x8F00FBF0;
 			opcode |= (imm8 << 16) | (imm3 << 28) | (imm1 << 10) | imm4;
-			
-			writeInt(P, opcode);			
+
+			writeInt(P, opcode);
 			break;
 		}
-		
+
 		//case R_ARM_NONE:
 		//case R_ARM_V4BX:
 		case R_ARM_RBASE:
 			//Modulemgr ignores these entries
 			break;
-			
+
 		default:
 			throw new MalformedElfException("Unknown rel type " + r_type);
 		}
 	}
-	
+
 	private void markupInfo(StructConverter info, Address addr, int P) throws Exception {
 		ctx.createData(addr, info.toDataType());
 		ctx.listing.setComment(addr, CodeUnit.PRE_COMMENT, String.format("Relocation target: 0x%08X", P));
 	}
-	
+
 	private void processPrx1Reftable(Address infoAddr, int destVA) throws Exception {
 		while (ctx.flatAPI.getInt(infoAddr) != 0) {
 			Prx1RefInfo info = new Prx1RefInfo(ctx.getBinaryReader(infoAddr));
 			apply_one_relocation(info.reltype, destVA, info.addend, info.P);
-			
+
 			markupInfo(info, infoAddr, info.P);
 			infoAddr = infoAddr.add(Prx1RefInfo.SIZE);
 		}
 	}
-	
+
 	private void processPrx2Reftable(Address infoAddr, Address maxAddr, int destVA) throws Exception {
 		while (infoAddr.compareTo(maxAddr) < 0) {
 			final int form = (ctx.flatAPI.getInt(infoAddr) & 0xF);
@@ -291,9 +291,9 @@ public class ArmRelocator {
 			case 1: {
 				Prx2RefInfoForm1 info = new Prx2RefInfoForm1(ctx.getBinaryReader(infoAddr));
 				final int P = (int)((ctx.elfEhdr.programHeaders[info.segment].p_vaddr + info.offset) & 0xFFFFFFFFL);
-				
+
 				apply_one_relocation(info.reltype, destVA, info.addend, P);
-				
+
 				markupInfo(info, infoAddr, P);
 				infoAddr = infoAddr.add(Prx2RefInfoForm1.SIZE);
 				break;
@@ -303,7 +303,7 @@ public class ArmRelocator {
 				final int P = (int)((ctx.elfEhdr.programHeaders[info.segment].p_vaddr + info.offset) & 0xFFFFFFFFL);
 
 				apply_one_relocation(info.reltype, destVA, info.addend, P);
-				
+
 				markupInfo(info, infoAddr, P);
 				infoAddr = infoAddr.add(Prx2RefInfoForm2.SIZE);
 				break;
@@ -312,12 +312,12 @@ public class ArmRelocator {
 					throw new MalformedElfException("Invalid refinfo form " + form);
 			}
 		}
-		
+
 		if (infoAddr.compareTo(maxAddr) != 0) {
 			throw new MalformedElfException("Reftable overflow");
 		}
 	}
-	
+
 	/**
 	 * Parse a reference table and perform all the relocations it contains.
 	 * @param refTableAddr 	Address of the reference table
@@ -325,9 +325,9 @@ public class ArmRelocator {
 	 */
 	public void processReftable(Address refTableAddr, Address destAddr) throws Exception {
 		__allocBlk();
-		
+
 		final int destVA = (int)destAddr.getUnsignedOffset();
-		
+
 		if (ctx.elfEhdr.isPrx1ELF()) {
 			processPrx1Reftable(refTableAddr, destVA);
 		} else {

--- a/src/main/java/vitaloaderredux/arm_relocation/Prx1RefInfo.java
+++ b/src/main/java/vitaloaderredux/arm_relocation/Prx1RefInfo.java
@@ -14,11 +14,11 @@ import vitaloaderredux.misc.Utils;
 //Prx1 reference information
 public class Prx1RefInfo implements StructConverter {
 	static public final int SIZE = 8;
-	
+
 	public final int reltype;
 	public final int addend;
 	public final int P;
-	
+
 	public DataType toDataType() {
 		StructureDataType dt = new StructureDataType(Datatypes.SCE_TYPES_CATPATH, "Prx1RefInfo", 0);
 		dt.setPackingEnabled(true);
@@ -28,23 +28,23 @@ public class Prx1RefInfo implements StructConverter {
 		} catch (InvalidDataTypeException e) {
 			throw new RuntimeException(e);
 		}
-		
+
 		dt.add(Datatypes.ptr, "P", "Virtual address where the reference lies");
-		
-		
+
+
 		Utils.assertStructureSize(dt, SIZE);
 		return dt;
 	}
-	
+
 	public Prx1RefInfo(BinaryReader reader) throws IOException {
 		BitfieldReader bfr = new BitfieldReader(reader.readNextInt());
-		
+
 		reltype = bfr.consume(8);
 		addend = bfr.consumeSEXT(24);
 		P = reader.readNextInt();
-		
+
 		bfr.assertFullConsumption("Prx1RefInfo");
 		Utils.assertBRSize("Prx1RefInfo", reader, SIZE);
 	}
-	
+
 }

--- a/src/main/java/vitaloaderredux/arm_relocation/Prx2RefInfoForm1.java
+++ b/src/main/java/vitaloaderredux/arm_relocation/Prx2RefInfoForm1.java
@@ -14,12 +14,12 @@ import vitaloaderredux.misc.Utils;
 //Form 1 reference information (used in reftables)
 public class Prx2RefInfoForm1 implements StructConverter  {
 	static public final int SIZE = 8;
-	
+
 	public final int segment;
 	public final int offset;
 	public final int addend;
 	public final int reltype;
-	
+
 	public DataType toDataType() {
 		StructureDataType dt = new StructureDataType(Datatypes.SCE_TYPES_CATPATH, "Prx2RefInfoForm1", 0);
 		dt.setPackingEnabled(true);
@@ -31,26 +31,26 @@ public class Prx2RefInfoForm1 implements StructConverter  {
 		} catch (InvalidDataTypeException e) {
 			throw new RuntimeException(e);
 		}
-		
+
 		dt.add(Datatypes.u32, "offset", "Offset where reference lies in segment (r_offset)");
-		
+
 		Utils.assertStructureSize(dt, SIZE);
 		return dt;
 	}
-	
+
 	public Prx2RefInfoForm1(BinaryReader reader) throws IOException {
 		BitfieldReader bfr = new BitfieldReader(reader.readNextInt());
-		
+
 		int form = bfr.consume(4);
 		if (form != 1) {
 			throw new IllegalArgumentException("Binary reader doesn't point to a form 1 RefInfo");
 		}
-		
+
 		segment = bfr.consume(4);
 		reltype = bfr.consume(8);
 		addend = bfr.consumeSEXT(16);
 		offset = reader.readNextInt();
-		
+
 		bfr.assertFullConsumption("Prx2RefInfoForm1");
 		Utils.assertBRSize("Prx2RefInfoForm1", reader, SIZE);
 	}

--- a/src/main/java/vitaloaderredux/arm_relocation/Prx2RefInfoForm2.java
+++ b/src/main/java/vitaloaderredux/arm_relocation/Prx2RefInfoForm2.java
@@ -14,12 +14,12 @@ import vitaloaderredux.misc.Utils;
 //Form 2 reference information (used in reftables)
 public class Prx2RefInfoForm2 implements StructConverter {
 	static public final int SIZE = 12;
-	
+
 	public final int segment;
 	public final int offset;
 	public final int addend;
 	public final int reltype;
-	
+
 	public DataType toDataType() {
 		StructureDataType dt = new StructureDataType(Datatypes.SCE_TYPES_CATPATH, "Prx2RefInfoForm2", 0);
 		dt.setPackingEnabled(true);
@@ -31,28 +31,28 @@ public class Prx2RefInfoForm2 implements StructConverter {
 		} catch (InvalidDataTypeException e) {
 			throw new RuntimeException(e);
 		}
-		
+
 		dt.add(Datatypes.u32, "addend", "Relocation addend (r_addend)");
 		dt.add(Datatypes.u32, "offset", "Offset where reference lies in segment (r_offset)");
-		
+
 		Utils.assertStructureSize(dt, SIZE);
 		return dt;
 	}
-	
+
 	public Prx2RefInfoForm2(BinaryReader reader) throws IOException {
 		BitfieldReader bfr = new BitfieldReader(reader.readNextShort());
 		reader.readNextShort(); //16 unused bits
-		
+
 		int form = bfr.consume(4);
 		if (form != 2) {
 			throw new IllegalArgumentException("Binary reader doesn't point to a form 2 RefInfo");
 		}
-		
+
 		segment = bfr.consume(4);
 		reltype = bfr.consume(8);
 		addend = reader.readNextInt();
 		offset = reader.readNextInt();
-		
+
 		bfr.assertFullConsumption("Prx2RefInfoForm2");
 		Utils.assertBRSize("Prx2RefInfoForm2", reader, SIZE);
 	}

--- a/src/main/java/vitaloaderredux/database/LibraryToModuleDatabase.java
+++ b/src/main/java/vitaloaderredux/database/LibraryToModuleDatabase.java
@@ -20,38 +20,38 @@ public class LibraryToModuleDatabase {
 	 * LN->FN database is simply a YAML file with key:value pairs mapping
 	 * file names to an array of library names.
 	 * This object constructs the reverse mapping.
-	 * 
+	 *
 	 * Example database file
 	 *
 	 * sysmem.skprx:
 	 * 	- SceSysmem
 	 * 	- SceSysmemForKernel
-	 * 
+	 *
 	 * threadmgr.skprx:
 	 * 	- SceThreadmgr
 	 */
-	
+
 	private final String DATABASE_NAME = "BuiltinLibraryToModuleDatabase.yaml";
 	private final Map<String, String> database;
-	
+
 	public LibraryToModuleDatabase(MessageLog logger) {
 		database = new HashMap<String, String>();
-		
+
 		try {
 			YamlReader yamlReader = new YamlReader(new FileReader(Application.getModuleDataFile(DATABASE_NAME).getFile(false)));
-			
+
 			@SuppressWarnings("rawtypes") //Root YAML node is always a generic Map - this is fine.
 			Map root = (Map)yamlReader.read();
-			
+
 			for (Object key : root.keySet()) {
 				if (key instanceof String) {
 					Object value = root.get(key);
 					if (value instanceof List) {
 						String fileName = (String)key;
-						
+
 						@SuppressWarnings("rawtypes") //Already checked we have a List - this is fine.
 						List libraries = (List)value;
-						
+
 						for (Object elem : libraries) {
 							if (elem instanceof String) {
 								database.put((String)elem, fileName);
@@ -66,13 +66,13 @@ public class LibraryToModuleDatabase {
 					logger.appendMsg("Skipped YAML node " + key + ": key is not a string.");
 				}
 			}
-			
+
 		} catch (Exception e) {
 			logger.appendMsg("Exception when reading the library to module file names database:");
 			logger.appendException(e);
 		}
 	}
-	
+
 	public String lookup(String libraryName) {
 		return database.get(libraryName);
 	}

--- a/src/main/java/vitaloaderredux/database/NIDDatabase.java
+++ b/src/main/java/vitaloaderredux/database/NIDDatabase.java
@@ -1,109 +1,144 @@
 package vitaloaderredux.database;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.BiPredicate;
+import java.util.stream.Stream;
 
-import com.esotericsoftware.yamlbeans.YamlException;
 import com.esotericsoftware.yamlbeans.YamlReader;
 
+import ghidra.app.util.importer.MessageLog;
+
 public class NIDDatabase {
-	private class PerLibraryDatabase {
-		private HashMap<Integer, String> functions = new HashMap<Integer, String>();
-		private HashMap<Integer, String> variables = new HashMap<Integer, String>();
+	private final Library DUMMY_LIB = new Library("<dummy>");
+	private HashMap<String, Library> nameToLibraryMap = new HashMap<String, Library>();
 
-		public void addFunction(int funcNID, String funcName) {
-			functions.put(funcNID, funcName);
-		}
+	public void loadFromFile(File databaseFile, MessageLog log) throws IOException {
+		YamlReader reader = new YamlReader(new FileReader(databaseFile));
+		DB_File db = reader.read(DB_File.class);
 
-		public void addVariable(int varNID, String varName) {
-			variables.put(varNID, varName);
-		}
+		db.modules.forEach((_modname, mod) -> {
+			mod.libraries.forEach((libname, libent) -> {
+				Library lib = nameToLibraryMap.get(libname);
+				if (lib == null) {
+					/* Library doesn't exist - create new one */
+					lib = new Library(libname);
+					nameToLibraryMap.put(libname, lib);
+				}
 
-		public String getFunctionName(int funcNID) {
-			return functions.get(funcNID);
-		}
-
-		public String getVariableName(int varNID) {
-			return variables.get(varNID);
-		}
+				lib.fillInFromDatabase(libent, log);
+			});
+		});
 	}
 
-	private HashMap<String, PerLibraryDatabase> nameToLibraryMap = new HashMap<String, PerLibraryDatabase>();
-	private PerLibraryDatabase findLibrary(String name) {
-		return nameToLibraryMap.get(name);
+	public void loadFromDirectory(File databaseDirectory, boolean logAllFiles, MessageLog log) throws IOException {
+		assert (databaseDirectory.isDirectory());
+
+		BiPredicate<Path, BasicFileAttributes> isValidDatabaseFile = (path, file_attributes) -> {
+			String fileName = path.toFile().getName();
+			return file_attributes.isRegularFile() && (fileName.endsWith(".yml") || fileName.endsWith(".yaml"));
+		};
+
+		/* find and load all .yml/.yaml files in databaseDirectory or below */
+		try (Stream<Path> dbf = Files.find(databaseDirectory.toPath(), Integer.MAX_VALUE, isValidDatabaseFile)) {
+			dbf.forEach((p) -> {
+				try {
+					loadFromFile(p.toFile(), log);
+					if (logAllFiles) {
+						log.appendMsg("Loaded NIDs from " + p.toString());
+					}
+				} catch (IOException e) {
+					log.appendMsg("Failed to load NIDs from " + p.toString() + ":");
+					log.appendException(e);
+				}
+			});
+		}
 	}
 
 	public String getFunctionName(String libraryName, int functionNID) {
-		PerLibraryDatabase libdb = findLibrary(libraryName);
-		return (libdb == null) ? null : libdb.getFunctionName(functionNID);
+		return lib4name(libraryName).getFunctionName(functionNID);
 	}
 
 	public String getVariableName(String libraryName, int variableNID) {
-		PerLibraryDatabase libdb = findLibrary(libraryName);
-		return (libdb == null) ? null : libdb.getVariableName(variableNID);
+		return lib4name(libraryName).getVariableName(variableNID);
 	}
 
-	/* Glue classes for YAML data
-	 *
-	 * Note that we have to use long/Long because YamlBeans will throw an
-	 * exception when assigning a negative (>= 0x8000_0000) value into int/Integer.
-	 * */
+	private Library lib4name(String libraryName) {
+		return nameToLibraryMap.getOrDefault(libraryName, DUMMY_LIB);
+	}
+	
+	/* Helper class */
+	private class Library {
+		public final String libName;
+		private HashMap<Integer, String> functions = new HashMap<Integer, String>();
+		private HashMap<Integer, String> variables = new HashMap<Integer, String>();
 
-	@SuppressWarnings("unused")
-	private static class YAML_Database {
-		public int version;
-		public String firmware;
-		public Map<String, YAML_Module> modules;
+		public Library(String name) {
+			libName = name;
+		}
+
+		public void fillInFromDatabase(DB_Library dbLib, MessageLog log) {
+			if (dbLib.functions != null) {
+				dbLib.functions.forEach((funcName, longNid) -> {
+					int nid = longNid.intValue();
+					String oldName = functions.put(nid, funcName);
+					if (oldName != null) {
+						log.appendMsg(String.format("Function %s_%08X: name conflict ('%s' overwritten with '%s')",
+								libName, nid, oldName, funcName));
+					}
+				});
+			}
+
+			if (dbLib.variables != null) {
+				dbLib.variables.forEach((varName, longNid) -> {
+					int nid = longNid.intValue();
+					String oldName = variables.put(nid, varName);
+					if (oldName != null) {
+						log.appendMsg(String.format("Variable %s_%08X: name conflict ('%s' overwritten with '%s')",
+								libName, nid, oldName, varName));
+					}
+				});
+			}
+		}
+		
+		public String getFunctionName(int NID) {
+			return functions.get(NID);
+		}
+		
+		public String getVariableName(int NID) {
+			return variables.get(NID);
+		}
 	}
 
+	/* YAML deserialization classes */
 	@SuppressWarnings("unused")
-	private static class YAML_Module {
-		public long nid; public long fingerprint;
-		public Map<String, YAML_Library> libraries;
-	}
-
-	@SuppressWarnings("unused")
-	private static class YAML_Library {
+	private static class DB_Library {
 		public long nid;
-		public boolean kernel; public boolean syscall; //Support both names, although VitaSDK uses only former...
+		public String stubname;
+		public boolean kernel;
+		public boolean syscall;
 
 		public Map<String, Long> functions;
 		public Map<String, Long> variables;
 	}
 
-	public NIDDatabase(File databaseFile) throws IOException {
-		try {
-			YamlReader reader = new YamlReader(new FileReader(databaseFile));
-			YAML_Database database = reader.read(YAML_Database.class);
-
-			for (Map.Entry<String, YAML_Module> moduleMapEntry: database.modules.entrySet()) {
-				YAML_Module module = moduleMapEntry.getValue();
-
-				for (Map.Entry<String, YAML_Library> libraryMapEntry: module.libraries.entrySet()) {
-					String libraryName = libraryMapEntry.getKey();
-					YAML_Library library = libraryMapEntry.getValue();
-
-					PerLibraryDatabase libDB = new PerLibraryDatabase();
-					if (library.functions != null) {
-						for (Map.Entry<String, Long> it: library.functions.entrySet())
-							libDB.addFunction(it.getValue().intValue(), it.getKey());
-					}
-
-					if (library.variables != null) {
-						for (Map.Entry<String, Long> it: library.variables.entrySet())
-							libDB.addVariable(it.getValue().intValue(), it.getKey());
-					}
-
-					nameToLibraryMap.put(libraryName, libDB);
-				}
-			}
-		} catch (FileNotFoundException | YamlException e) {
-			throw e;
-		}
+	@SuppressWarnings("unused")
+	private static class DB_Module {
+		public long nid;
+		public long fingerprint;
+		public Map<String, DB_Library> libraries;
 	}
 
+	@SuppressWarnings("unused")
+	private static class DB_File {
+		public int version;
+		public String firmware;
+		public Map<String, DB_Module> modules;
+	}
 }

--- a/src/main/java/vitaloaderredux/database/NIDDatabase.java
+++ b/src/main/java/vitaloaderredux/database/NIDDatabase.java
@@ -14,75 +14,75 @@ public class NIDDatabase {
 	private class PerLibraryDatabase {
 		private HashMap<Integer, String> functions = new HashMap<Integer, String>();
 		private HashMap<Integer, String> variables = new HashMap<Integer, String>();
-		
+
 		public void addFunction(int funcNID, String funcName) {
 			functions.put(funcNID, funcName);
 		}
-		
+
 		public void addVariable(int varNID, String varName) {
 			variables.put(varNID, varName);
 		}
-		
+
 		public String getFunctionName(int funcNID) {
 			return functions.get(funcNID);
 		}
-		
+
 		public String getVariableName(int varNID) {
 			return variables.get(varNID);
 		}
 	}
-	
+
 	private HashMap<String, PerLibraryDatabase> nameToLibraryMap = new HashMap<String, PerLibraryDatabase>();
 	private PerLibraryDatabase findLibrary(String name) {
 		return nameToLibraryMap.get(name);
 	}
-	
+
 	public String getFunctionName(String libraryName, int functionNID) {
 		PerLibraryDatabase libdb = findLibrary(libraryName);
 		return (libdb == null) ? null : libdb.getFunctionName(functionNID);
 	}
-	
+
 	public String getVariableName(String libraryName, int variableNID) {
 		PerLibraryDatabase libdb = findLibrary(libraryName);
 		return (libdb == null) ? null : libdb.getVariableName(variableNID);
 	}
-	
-	/* Glue classes for YAML data 
-	 * 
+
+	/* Glue classes for YAML data
+	 *
 	 * Note that we have to use long/Long because YamlBeans will throw an
 	 * exception when assigning a negative (>= 0x8000_0000) value into int/Integer.
 	 * */
-	
+
 	@SuppressWarnings("unused")
 	private static class YAML_Database {
 		public int version;
 		public String firmware;
 		public Map<String, YAML_Module> modules;
 	}
-	
+
 	@SuppressWarnings("unused")
 	private static class YAML_Module {
-		public long nid; public long fingerprint; 
+		public long nid; public long fingerprint;
 		public Map<String, YAML_Library> libraries;
 	}
-	
+
 	@SuppressWarnings("unused")
 	private static class YAML_Library {
 		public long nid;
 		public boolean kernel; public boolean syscall; //Support both names, although VitaSDK uses only former...
-		
+
 		public Map<String, Long> functions;
 		public Map<String, Long> variables;
 	}
-	
+
 	public NIDDatabase(File databaseFile) throws IOException {
 		try {
 			YamlReader reader = new YamlReader(new FileReader(databaseFile));
 			YAML_Database database = reader.read(YAML_Database.class);
-			
+
 			for (Map.Entry<String, YAML_Module> moduleMapEntry: database.modules.entrySet()) {
 				YAML_Module module = moduleMapEntry.getValue();
-				
+
 				for (Map.Entry<String, YAML_Library> libraryMapEntry: module.libraries.entrySet()) {
 					String libraryName = libraryMapEntry.getKey();
 					YAML_Library library = libraryMapEntry.getValue();
@@ -92,12 +92,12 @@ public class NIDDatabase {
 						for (Map.Entry<String, Long> it: library.functions.entrySet())
 							libDB.addFunction(it.getValue().intValue(), it.getKey());
 					}
-					
+
 					if (library.variables != null) {
 						for (Map.Entry<String, Long> it: library.variables.entrySet())
 							libDB.addVariable(it.getValue().intValue(), it.getKey());
 					}
-					
+
 					nameToLibraryMap.put(libraryName, libDB);
 				}
 			}

--- a/src/main/java/vitaloaderredux/elf/ElfEhdr.java
+++ b/src/main/java/vitaloaderredux/elf/ElfEhdr.java
@@ -23,15 +23,15 @@ import ghidra.util.exception.DuplicateNameException;
 import vitaloaderredux.misc.Datatypes;
 
 public class ElfEhdr implements StructConverter, Writeable {
-	
+
 	//For e_type
-	static private final int ETSCEEXEC = 0xFE00, 
+	static private final int ETSCEEXEC = 0xFE00,
 		ETSCERELEXEC = 0xFE04, ETSCEARMRELEXEC = 0xFFA5;
-	
+
 	static private final int EHDR_SIZE = 52, PHDR_SIZE = 0x20, SHDR_SIZE = 0x28;
-	
+
 	static public final short EM_CYGNUS_MEP = (short)0xF00D;
-	
+
 	public enum ElfType implements StructConverter {
 		ET_REL, ET_EXEC, ET_CORE,
 		ET_SCE_EXEC, ET_SCE_RELEXEC, ET_SCE_ARMRELEXEC;
@@ -46,7 +46,7 @@ public class ElfEhdr implements StructConverter, Writeable {
 			if (itype == ETSCEARMRELEXEC) return ET_SCE_ARMRELEXEC;
 			throw new IllegalArgumentException("Unreachable");
 		}
-				
+
 		public String description() {
 			switch (this) {
 			case ET_REL: return "Relocatable executable";
@@ -64,7 +64,7 @@ public class ElfEhdr implements StructConverter, Writeable {
 					(this == ET_SCE_RELEXEC) ||
 					(this == ET_SCE_ARMRELEXEC);
 		}
-		
+
 		static public DataType getDataType() {
 			if (ELFTYPE_ENUM == null) {
 				ELFTYPE_ENUM = new EnumDataType(Datatypes.ELF_CATPATH, "Elf32_EType", UnsignedShortDataType.dataType.getLength());
@@ -78,13 +78,13 @@ public class ElfEhdr implements StructConverter, Writeable {
 			return ELFTYPE_ENUM;
 		}
 		static EnumDataType ELFTYPE_ENUM = null;
-		
+
 		@Override
 		public DataType toDataType() throws DuplicateNameException, IOException {
 			return getDataType();
 		}
 	}
-	
+
 	private static EnumDataType e_machine_enum = null;
 	private static DataType GetEMachineDataType() {
 		if (e_machine_enum == null) {
@@ -94,13 +94,13 @@ public class ElfEhdr implements StructConverter, Writeable {
 		}
 		return e_machine_enum;
 	}
-	
+
 	public final byte ei_osabi;
 	public final byte ei_abiversion;
 	public final byte ei_pad[];
-	
+
 	public final short e_machine;
-	
+
 	public final short e_type;
 	public final ElfType execType;
 	public final long e_entry;
@@ -113,14 +113,14 @@ public class ElfEhdr implements StructConverter, Writeable {
 	public final int e_shentsize;
 	public final int e_shnum;
 	public final int e_shstrndx;
-	
+
 	public ElfPhdr[] programHeaders = null;
 	public ElfShdr[] sectionHeaders = null;
-	
+
 	public final ByteProvider byteProvider;
-	
+
 	/**
-	 * 
+	 *
 	 * @param provider
 	 * @throws IOException when a BinaryReader error occurs.
 	 * @throws IllegalArgumentException when the ELF header is invalid.
@@ -128,33 +128,33 @@ public class ElfEhdr implements StructConverter, Writeable {
 	public ElfEhdr(ByteProvider provider) throws IOException {
 		byteProvider = provider;
 		BinaryReader reader = new BinaryReader(byteProvider, true);
-	
+
 		byte magic0 = reader.readNextByte();
 		String magic123 = reader.readNextAsciiString(ElfConstants.MAGIC_STR_LEN);
 		if (magic0 != ElfConstants.MAGIC_NUM || !magic123.equals(ElfConstants.MAGIC_STR))
 		{
 			throw new MalformedElfException("No ELF magic");
 		}
-		
+
 		final byte ei_class = reader.readNextByte();
 		if (ei_class != ElfConstants.ELF_CLASS_32) {
 			throw new UnsupportedElfException("Unexpected EI_CLASS");
 		}
-		
+
 		final byte ei_data = reader.readNextByte();
 		if (ei_data != ElfConstants.ELF_DATA_LE) {
 			throw new UnsupportedElfException("Unexpected EI_DATA");
 		}
-		
+
 		final byte ei_version = reader.readNextByte();
 		if (ei_version != ElfConstants.EV_CURRENT) {
 			throw new UnsupportedElfException("Unexpected EI_VERSION");
 		}
-		
+
 		ei_osabi = reader.readNextByte();
 		ei_abiversion = reader.readNextByte();
 		ei_pad = reader.readNextByteArray(7);
-		
+
 		e_type = reader.readNextShort();
 		execType = ElfType.fromInteger(e_type);
 
@@ -162,51 +162,51 @@ public class ElfEhdr implements StructConverter, Writeable {
 		if (e_machine != ElfConstants.EM_ARM && e_machine != EM_CYGNUS_MEP) {
 			throw new UnsupportedElfException("Unexpected e_machine");
 		}
-		
+
 		long e_version = reader.readNextUnsignedInt();
 		if (e_version != ElfConstants.EV_CURRENT) {
 			throw new UnsupportedElfException("Unexpected e_version");
 		}
-		
+
 		e_entry = reader.readNextUnsignedInt();
-		
+
 		e_phoff = reader.readNextUnsignedInt();
 		if (e_phoff > provider.length()) {
-			throw new MalformedElfException("e_phoff " + e_phoff + " is too big (max = " + provider.length() + ")"); 
+			throw new MalformedElfException("e_phoff " + e_phoff + " is too big (max = " + provider.length() + ")");
 		}
-		
+
 		e_shoff = reader.readNextUnsignedInt();
 		if (e_shoff > provider.length()) {
 			throw new MalformedElfException("e_shoff " + e_shoff + " is too big (max = " + provider.length() + ")");
 		}
-		
+
 		e_flags = reader.readNextUnsignedInt();
-		
+
 		int e_ehsize = reader.readNextUnsignedShort();
 		if (e_ehsize != EHDR_SIZE) {
 			throw new UnsupportedElfException("Unexpected e_ehsize " + e_ehsize);
 		}
-		
+
 		int e_phentsize = reader.readNextUnsignedShort();
 		if (e_phentsize != PHDR_SIZE) {
 			throw new UnsupportedElfException("Unexpected e_phentsize " + e_phentsize);
 		}
-		
+
 		e_phnum = reader.readNextUnsignedShort();
-		
+
 		e_shentsize = reader.readNextUnsignedShort();
 		if (e_shentsize != 0 && e_shentsize != SHDR_SIZE) { //e_shentsize is 0 when sections are stripped
 			throw new UnsupportedElfException("Unexpected e_shentsize " + e_shentsize);
 		}
-		
+
 		e_shnum = reader.readNextUnsignedShort();
 		e_shstrndx = reader.readNextUnsignedShort();
 		if (e_shnum > 0 && e_shstrndx >= e_shnum) {
 			throw new MalformedElfException(String.format("e_shstrndx (%d) >= e_shnum (%d)", e_shstrndx, e_shnum));
 		}
-		
+
 		parseProgramHeaders();
-		
+
 		try {
 			parseSegmentHeaders();
 			parseSegmentNames();
@@ -214,15 +214,15 @@ public class ElfEhdr implements StructConverter, Writeable {
 			//Silently swallow... sections aren't very important.
 		}
 	}
-	
+
 	public int getImageBase() {
 		if (e_phnum == 0) {
 			return 0;
 		}
-		
+
 		//Must use long to ensure comparisions work as expected.
 		long base = 0x81000000;
-		
+
 		//Find smallest p_vaddr
 		for (ElfPhdr Phdr: programHeaders) {
 			if (Phdr.p_type == ElfProgramHeaderConstants.PT_LOAD && Phdr.p_vaddr < base) {
@@ -231,27 +231,27 @@ public class ElfEhdr implements StructConverter, Writeable {
 		}
 		return (int)(base & 0xFFFFFFFFl);
 	}
-	
+
 	public class ModInfoLocation {
 		public final int segmentIndex;
 		public final int segmentOffset;
 		public final int fileOffset;
-		
+
 		public ModInfoLocation(int segmentIdx, int segmentFileOffset, int offsetInSegment) {
 			segmentIndex = segmentIdx;
 			segmentOffset = offsetInSegment;
 			fileOffset = segmentFileOffset + offsetInSegment;
 		}
 	}
-	
+
 	//This method is only valid for ARM ELF.
 	public ModInfoLocation getModuleInfoLocation() throws MalformedElfException, UnsupportedElfException {
 		if (e_machine != ElfConstants.EM_ARM) {
 			throw new UnsupportedElfException("Only ARM ELFs have a SceModuleInfo");
 		}
-		
+
 		//If the ELF has sections, try to find .sceModuleInfo.rodata
-		
+
 		//TODO: is this correct?
 		//TODO: find segment metadata by section
 		/*
@@ -263,7 +263,7 @@ public class ElfEhdr implements StructConverter, Writeable {
 			}
 		}
 		*/
-		
+
 		//Legacy ELF format (Prx1): module info FILE offset is stored in first segment's p_paddr.
 		if (isPrx1ELF()) {
 			ElfPhdr Phdr = programHeaders[0];
@@ -271,10 +271,10 @@ public class ElfEhdr implements StructConverter, Writeable {
 			if (modInfoOffset < 0) {
 				throw new MalformedElfException("Prx1 ELF: bad SceModuleInfo offset");
 			}
-			
+
 			return new ModInfoLocation(0, (int)Phdr.p_offset, modInfoOffset);
 		}
-		
+
 		//How does Modulemgr find the SceModuleInfo? Why reinvent the wheel?
 		//
 		//Answer: in 4.00, the following method is always used:
@@ -284,7 +284,7 @@ public class ElfEhdr implements StructConverter, Writeable {
 		//
 		//RE of older firmwares is required, but alas, I think
 		//we'll have to resort to hacks to have universal support.
-		
+
 		//For some ET_SCE_EXEC, module info offset is stored in the segment's p_paddr.
 		//TODO: is this true?!
 		for (int i = 0; i < e_phnum; i++) {
@@ -295,45 +295,45 @@ public class ElfEhdr implements StructConverter, Writeable {
 				return new ModInfoLocation(i, (int)Phdr.p_offset, (int)Phdr.p_paddr);
 			}
 		}
-		
+
 
 		//For ET_SCE_RELEXEC and some ET_SCE_EXEC, the Ehdr's e_entry stores the segment:offset to the SceModuleInfo.
 		//Top two bits = segment index, bottom 30 bits = offset in segment.
 		byte segNdx = (byte)((e_entry >> 30) & 0x3);
 		int segOffset = (int)(e_entry & 0x3FFFFFFF);
-		
+
 		if (segNdx > e_phnum) {
 			throw new MalformedElfException(String.format("segNdx (%d) > e_phnum (%d)", segNdx, e_phnum));
 		}
-		
+
 		ElfPhdr segHdr = programHeaders[segNdx];
 		if (segHdr.p_type != ElfProgramHeaderConstants.PT_LOAD) {
 			throw new MalformedElfException(String.format("Illegal segment type 0x%X for SceModuleInfo", segHdr.p_type));
 		}
-		
+
 		if (segOffset > segHdr.p_filesz) {
 			throw new MalformedElfException(String.format("segOffset (%d) > seg.p_filesz (%d)", segOffset, segHdr.p_filesz));
 		}
-		
+
 		//TODO: is this correct?
 		return new ModInfoLocation(segNdx, (int)segHdr.p_offset, segOffset);
 	}
-	
+
 	/**
 	 * Get the offset in file of the SceModuleInfo structure.
 	 * @return File offset of SceModuleInfo, or -1 if not found
-	 * @throws UnsupportedElfException 
-	 * @throws MalformedElfException 
+	 * @throws UnsupportedElfException
+	 * @throws MalformedElfException
 	 */
 	public long getModuleInfoFileOffset() throws MalformedElfException, UnsupportedElfException {
 		ModInfoLocation loc = getModuleInfoLocation();
 		return loc.fileOffset;
 	}
-	
+
 	private BinaryReader makeReaderForOffset(long offset) {
 		return new BinaryReader(byteProvider, LittleEndianDataConverter.INSTANCE, offset);
 	}
-	
+
 	private void parseProgramHeaders() throws IOException {
 		if (e_phnum > 0) {
 			programHeaders = new ElfPhdr[e_phnum];
@@ -343,7 +343,7 @@ public class ElfEhdr implements StructConverter, Writeable {
 			}
 		}
 	}
-	
+
 	private void parseSegmentHeaders() throws IOException {
 		if (e_shnum > 0) {
 			sectionHeaders = new ElfShdr[e_shnum];
@@ -357,11 +357,11 @@ public class ElfEhdr implements StructConverter, Writeable {
 	private void parseSegmentNames() throws IOException {
 		if (e_shnum <= 0)
 			return;
-		
+
 		if (e_shstrndx >= 0) {
 			ElfShdr namesSection = sectionHeaders[e_shstrndx];
 			BinaryReader namesReader = makeReaderForOffset(namesSection.sh_offset);
-				
+
 			for (int i = 0; i < e_shnum; i++) {
 				ElfShdr section = sectionHeaders[i];
 				String name = namesReader.readAsciiString(section.sh_name);
@@ -376,7 +376,7 @@ public class ElfEhdr implements StructConverter, Writeable {
 					sectionHeaders[i].name = String.format("SECTION_%d", i);
 			}
 		}
-		
+
 	}
 
 	public static DataType getDataType() {
@@ -385,7 +385,7 @@ public class ElfEhdr implements StructConverter, Writeable {
 		DataType u16 = UnsignedShortDataType.dataType;
 		DataType u32 = UnsignedIntegerDataType.dataType;
 		DataType char8 = CharDataType.dataType;
-		
+
 		StructureDataType dt = new StructureDataType(Datatypes.ELF_CATPATH, "Elf32_Ehdr", 0);
 		dt.add(u8, "ei_magic", "0x7F");
 		dt.add(new ArrayDataType(char8, 3, char8.getLength()), "ei_magic_str", "ELF");
@@ -410,12 +410,12 @@ public class ElfEhdr implements StructConverter, Writeable {
 		dt.add(u16, "e_shstrndx", "Index of string section");
 		return dt;
 	}
-	
+
 	@Override
 	public DataType toDataType() throws DuplicateNameException, IOException {
 		return getDataType();
 	}
-	
+
 	@Override
 	public void write(RandomAccessFile raf, DataConverter dc) throws IOException {
 		raf.write((byte)0x7F);
@@ -428,9 +428,9 @@ public class ElfEhdr implements StructConverter, Writeable {
 		raf.write(ei_osabi);
 		raf.write(ei_abiversion);
 		raf.write(ei_pad);
-		
+
 		DataConverter LEDC = LittleEndianDataConverter.INSTANCE;
-		
+
 		//Multi-byte fields must be converted to be written in little endian
 		raf.write(LEDC.getBytes(e_type));
 		raf.write(LEDC.getBytes(e_machine));
@@ -446,17 +446,17 @@ public class ElfEhdr implements StructConverter, Writeable {
 		raf.write(LEDC.getBytes((short)e_shnum));
 		raf.write(LEDC.getBytes((short)e_shstrndx));
 	}
-	
+
 	public boolean isPrx1ELF() {
 		if (e_type == (short)ETSCEARMRELEXEC)
 			return true;
-		
+
 		if (e_type == ElfConstants.ET_EXEC)
 			return true;
-		
+
 		if (e_type == ElfConstants.ET_REL)
 			return true;
-		
+
 		//Either ET_SCE_EXEC, ET_SCE_RELEXEC or ET_CORE (which are generated by faps-coredump)
 		return false;
 	}

--- a/src/main/java/vitaloaderredux/elf/ElfPhdr.java
+++ b/src/main/java/vitaloaderredux/elf/ElfPhdr.java
@@ -20,7 +20,7 @@ public class ElfPhdr {
 
 	//Present on .data relocation segment, absent on .text relocation segment.
 	static public final int PF_DATA_RELA = 0x10000;
-	
+
 	/**
 	 * @return DataType for the p_type field
 	 */
@@ -36,7 +36,7 @@ public class ElfPhdr {
 		dt.add("PT_SCE_ARMRELA", PT_SCE_ARMRELA, "PRX1 relocation segment");
 		return dt;
 	}
-	
+
 	/**
 	 * @return DataType for the p_flags field
 	 */
@@ -47,11 +47,11 @@ public class ElfPhdr {
 		dt.add("PF_R", 4);
 		return dt;
 	}
-	
+
 	static public DataType getDataType() {
 		if (PHDR_DATATYPE == null) {
 			DataType uint = UnsignedIntegerDataType.dataType;
-			
+
 			//TODO: make p_flags a EnumDataType as well
 			PHDR_DATATYPE = new StructureDataType(Datatypes.ELF_CATPATH, "Elf32_Phdr", 0);
 			PHDR_DATATYPE.add(getPhdrTypeDataType(), "p_type", "");
@@ -66,7 +66,7 @@ public class ElfPhdr {
 		return PHDR_DATATYPE;
 	}
 	static StructureDataType PHDR_DATATYPE = null;
-	
+
 	public final long p_type;
 	public final long p_offset;
 	public final long p_vaddr;
@@ -75,10 +75,10 @@ public class ElfPhdr {
 	public final long p_memsz;
 	public final long p_flags;
 	public final long p_align;
-	
+
 	//User data. Can be used to store an object associated to the segment.
 	public Object userData;
-	
+
 	public ElfPhdr(BinaryReader reader) throws IOException {
 		p_type = reader.readNextUnsignedInt();
 		p_offset = reader.readNextUnsignedInt();

--- a/src/main/java/vitaloaderredux/elf/ElfShdr.java
+++ b/src/main/java/vitaloaderredux/elf/ElfShdr.java
@@ -40,7 +40,7 @@ public class ElfShdr {
 		//TODO: add SCE section header types
 		return dt;
 	}
-	
+
 	/**
 	 * @return DataType for the sh_flags field
 	 */
@@ -49,7 +49,7 @@ public class ElfShdr {
 		dt.add("SHF_WRITE", ElfSectionHeaderConstants.SHF_WRITE, "Writable section");
 		dt.add("SHF_ALLOC", ElfSectionHeaderConstants.SHF_ALLOC, "Section occupies memory during execution");
 		dt.add("SHF_EXECINSTR", ElfSectionHeaderConstants.SHF_EXECINSTR, "Executable section");
-		
+
 		dt.add("SHF_MERGE", ElfSectionHeaderConstants.SHF_MERGE, "Section might be merged");
 		dt.add("SHF_STRINGS", ElfSectionHeaderConstants.SHF_STRINGS, "Section contains NUL-terminated strings");
 		dt.add("SHF_INFO_LINK", ElfSectionHeaderConstants.SHF_INFO_LINK, "sh_info holds an SHT index");
@@ -60,11 +60,11 @@ public class ElfShdr {
 		dt.add("SHF_COMPRESSED", ElfSectionHeaderConstants.SHF_COMPRESSED, "Section is compressed");
 		return dt;
 	}
-	
+
 	static public DataType getDataType() {
 		if (SHDR_DATATYPE == null) {
 			DataType uint = UnsignedIntegerDataType.dataType;
-			
+
 			//TODO: make sh_flags a EnumDataType as well
 			SHDR_DATATYPE = new StructureDataType(ELF_CATPATH, "Elf32_Shdr", 0);
 			SHDR_DATATYPE.add(uint, "sh_name", "");
@@ -81,7 +81,7 @@ public class ElfShdr {
 		return SHDR_DATATYPE;
 	}
 	static StructureDataType SHDR_DATATYPE = null;
-	
+
 	public final long sh_name;   //offset to name in .shstrtab section
 	public final long sh_type;   //section type
 	public final long sh_flags;  //section attributes
@@ -92,13 +92,13 @@ public class ElfShdr {
 	public final long sh_info;
 	public final long sh_addralign;
 	public final long sh_entsize;
-	
+
 	//Section name. Must be filled up by class user.
 	public String name = null;
-	
+
 	//User data. Can be used by class user to store an object associated to the section.
 	public Object userData;
-	
+
 	public ElfShdr(BinaryReader reader) throws IOException {
 		sh_name = reader.readNextUnsignedInt();
 		sh_type = reader.readNextUnsignedInt();

--- a/src/main/java/vitaloaderredux/loader/ArmElfPrxLoader.java
+++ b/src/main/java/vitaloaderredux/loader/ArmElfPrxLoader.java
@@ -60,7 +60,7 @@ import vitaloaderredux.scetypes.SceKernelLibraryStubTable_prx2arm;
 import vitaloaderredux.scetypes.SceModuleInfo;
 
 /**
- * 
+ *
  * @author CreepNT
  *
  * @implNote This parser may be less strict than the SceKernelModulemgr (S)ELF parser.
@@ -68,26 +68,26 @@ import vitaloaderredux.scetypes.SceModuleInfo;
  * it will be accepted by SceKernelModulemgr.
  */
 public class ArmElfPrxLoader extends AbstractLibrarySupportLoader {
-	
-	private static final LanguageCompilerSpecPair LANGUAGE = 
+
+	private static final LanguageCompilerSpecPair LANGUAGE =
 			new LanguageCompilerSpecPair("ARM:LE:32:v7", "default");
 
 	public static final String MODULE_INFO_LOCATOR_USRPROPNAME = "[VLR:ARM] SceModuleInfo locator";
 	public static final String IMPORTEXPORT_LOCATOR_USRPROPNAME = "[VLR:ARM] Imports/Exports locator";
-	
+
 	private static final String FILE_FORMAT_NAME = "ARM ELF-PRX for PlayStation\u00AEVita";
-	
+
 	private static final String VARIMPORT_BLOCK_ADDRESS_OPTNAME = "Variable Imports Block Base";
 	private static final String VARIMPORT_BLOCK_SIZE_OPTNAME = "Variable Imports Block Size";
 	private static final String VARIMPORT_SIZE_OPTNAME = "Imported Variables Size";
-	
+
 	private static final int NOACCESS = 0;
 	private static final int PF_R = ElfProgramHeaderConstants.PF_R;
 	private static final int PF_W = ElfProgramHeaderConstants.PF_W;
-	private static final int PF_X = ElfProgramHeaderConstants.PF_X; 
-	
+	private static final int PF_X = ElfProgramHeaderConstants.PF_X;
+
 	private static final Address OTHERAS_START = AddressSpace.OTHER_SPACE.getAddress(0);
-		
+
 	@Override
 	public String getName() {
 		return FILE_FORMAT_NAME;
@@ -96,15 +96,15 @@ public class ArmElfPrxLoader extends AbstractLibrarySupportLoader {
 	@Override
 	public Collection<LoadSpec> findSupportedLoadSpecs(ByteProvider provider) throws IOException {
 		List<LoadSpec> loadSpecs = new ArrayList<>();
-		
+
 		ElfEhdr ehdr;
-		
+
 		try {
 			ehdr = new ElfEhdr(provider);
 		} catch (IOException | IllegalArgumentException e) {
 			return loadSpecs;
 		}
-		
+
 		if (ehdr.e_machine != ElfConstants.EM_ARM)
 			return loadSpecs;
 
@@ -119,22 +119,22 @@ public class ArmElfPrxLoader extends AbstractLibrarySupportLoader {
 		if (modInfoOffset < 0) {
 			return loadSpecs;
 		}
-		
+
 		BinaryReader modInfoReader = new BinaryReader(provider, true);
 		modInfoReader.setPointerIndex(modInfoOffset + 4);
 		if (!SceModuleInfo.verifyModuleInfoName(modInfoReader, true)) {
 			return loadSpecs;
 		}
-		
+
 		loadSpecs.add(new LoadSpec(this, /* use a sensical default base address */ 0x81000000, LANGUAGE, true));
 		return loadSpecs;
 	}
-	
+
 	@Override
 	public List<Option> getDefaultOptions(ByteProvider provider, LoadSpec loadSpec,
 			DomainObject domainObject, boolean isLoadIntoProgram) {
 		List<Option> list = super.getDefaultOptions(provider, loadSpec, domainObject, isLoadIntoProgram);
-		
+
 		//Place at end of address space with 4KiB per variable, up to 128 variables
 		//Don't make block too big to avoid hindering navigation using the scroll bar!
 		list.add(new HexOption(VARIMPORT_BLOCK_ADDRESS_OPTNAME, 0xFFF00000L));
@@ -156,20 +156,20 @@ public class ArmElfPrxLoader extends AbstractLibrarySupportLoader {
 					}
 				}
 			}
-			
+
 			final int varImportSize = getVarImportSize(options);
 			final int varImportBlockSize = getVarImportBlockSize(options);
-			
+
 			if (varImportBlockSize < varImportSize) {
-				return String.format("VarImport block size is lower than variable size", 
+				return String.format("VarImport block size is lower than variable size",
 						varImportBlockSize, getVarImportSize(options));
 			}
-			
+
 			if ((varImportBlockSize / varImportSize) == 0) {
 				return "VarImport block too small to hold any variable";
 			}
 		}
-		
+
 		return super.validateOptions(provider, loadSpec, options, program);
 	}
 
@@ -182,20 +182,20 @@ public class ArmElfPrxLoader extends AbstractLibrarySupportLoader {
 	public int getTierPriority() {
 		return super.getTierPriority() - 1;
 	}
-	
+
 	/* -------------------------------------------------- */
-	
+
 	ArmElfPrxLoaderContext ctx = null;
 	FileBytes fileBytes = null;
-	
+
 	@Override
 	protected void load(ByteProvider provider, LoadSpec loadSpec, List<Option> options,
 			Program program, TaskMonitor taskMon, MessageLog log)
 			throws CancelledException, IOException {
-		
+
 		//Initialize loader context
 		ElfEhdr ehdr = new ElfEhdr(provider);
-		
+
 		//Set image base. This needs to be performed before any memory block is created
 		//because it tries to shift all memory blocks, but VARIMPORT block at 0xF0000000
 		//can't be and wraps around, causing an AddressOverflowException to be thrown.
@@ -207,30 +207,30 @@ public class ArmElfPrxLoader extends AbstractLibrarySupportLoader {
 			//because it intializes the relocator which creates the very MemoryBlock that breaks everything!
 			long imageBase = ehdr.getImageBase() & 0xFFFFFFFFl;
 			Address imageBaseAddress = program.getAddressFactory().getDefaultAddressSpace().getAddress(imageBase);
-			
+
 			program.setImageBase(imageBaseAddress, true);
 		} catch (AddressOverflowException | LockException | IllegalStateException | AddressOutOfBoundsException e) {
 			throw new LoadException(e);
 		}
-		
+
 		try {
 			ctx = new ArmElfPrxLoaderContext(program, ehdr, taskMon, log, provider.length(), options);
 		} catch (Exception e) {
 			throw new LoadException(e);
 		}
-		
+
 		//Obtain file bytes object from program
 		try (InputStream fileIn = provider.getInputStream(0); MonitoredInputStream mis = new MonitoredInputStream(fileIn, taskMon)) {
 			fileBytes = ctx.memory.createFileBytes(provider.getName(), 0, provider.length(), mis, taskMon);
 		}
-	
+
 		//Markup ELF Ehdr, Phdrs and Shdrs
 		createDataFromFileInOtherAS("ELF Ehdr", "ELF file header", 0, ElfEhdr.getDataType());
 		createDataFromFileInOtherAS("ELF Phdrs", "ELF program headers", ehdr.e_phoff, Datatypes.makeArray(ElfPhdr.getDataType(), ehdr.e_phnum));
 		if (ehdr.e_shnum > 0) {
 			createDataFromFileInOtherAS("ELF Shdrs", "ELF section headers", ehdr.e_shoff, Datatypes.makeArray(ElfShdr.getDataType(), ehdr.e_shnum));
 		}
-		
+
 		try {
 			//Always parse segments even if sections may be available.
 			//
@@ -241,7 +241,7 @@ public class ArmElfPrxLoader extends AbstractLibrarySupportLoader {
 		} catch (Exception e) {
 			throw new LoadException(e);
 		}
-		
+
 		try {
 			processModuleInfo();
 		} catch (CancelledException | IOException e) { //Rethrow as-is on cancel or IOException
@@ -249,7 +249,7 @@ public class ArmElfPrxLoader extends AbstractLibrarySupportLoader {
 		} catch (Exception e) { //Otherwise, rethrow as LoadException
 			throw new LoadException(e);
 		}
-		
+
 		//TODO: implement symbol table support
 		//SCE seems to use a non-standard(ish) symbol format, Ghidra chokes on it (all symbols are off-by-one).
 		/*
@@ -265,60 +265,60 @@ public class ArmElfPrxLoader extends AbstractLibrarySupportLoader {
 			}
 		}
 		*/
-		
+
 		//Set decorative metadata
 		program.setExecutableFormat(ArmElfPrxLoader.FILE_FORMAT_NAME);
 		addProgramProperties();
 	}
-	
+
 	private void addProgramProperties() throws CancelledException {
 		ctx.setMonitorMessage("Adding program properties...");
-		
+
 		Options properties = ctx.program.getOptions(Program.PROGRAM_INFO);
 		properties.setString("ELF Type", ctx.elfEhdr.execType.description() + " (" + ctx.elfEhdr.execType.toString() + ")");
 		properties.setBoolean("Relocatable", ctx.elfEhdr.execType.relocatable());
 		properties.setString("Image Base Address", String.format("0x%08X", ctx.elfEhdr.getImageBase()));
-		
+
 		final String fileKind = ctx.getFileKind();
 		if (fileKind != null) {
 			properties.setString("File Kind", fileKind);
 		}
-		
+
 		final String modSDKVersion = ctx.getModuleSDKVersion();
 		if (modSDKVersion != null) {
 			properties.setString("Module SDK Version", modSDKVersion);
 		}
-		
+
 		final String ppSDKVersion = ctx.getProcessParamSDKVersion();
 		if (ppSDKVersion != null) {
 			properties.setString("Process Param SDK Version", ppSDKVersion);
 		}
 	}
-	
+
 	private MemoryBlock importPTLOADSegment(ElfPhdr Phdr, int index) throws Exception {
 		//TODO: there is something special in p_flags that can extend the size of segments.
 		//More Modulemgr RE is required...
 		Address segmentLoadAddress = ctx.getAddressInDefaultAS((int)Phdr.p_vaddr);
 		String segmentName = "seg" + index;
 		MemoryBlock segmentBlock = null;
-		
-		if (Phdr.p_filesz > 0) {	
+
+		if (Phdr.p_filesz > 0) {
 			//Create a memory block filled with file bytes
 			segmentBlock = createFileBytesBlock(segmentName, segmentLoadAddress,
 					Phdr.p_offset, Phdr.p_filesz, "", PhdrFlagsToMemPerms(Phdr.p_flags), false);
-			
+
 			//If memsz > filesz, expand by creating a tail memory block and merging the empty and filebytes blocks together
 			if (Phdr.p_memsz > Phdr.p_filesz) {
 				long zeroPadLen = Phdr.p_memsz - Phdr.p_filesz;
-				
+
 				MemoryBlock padBlk = createZeroInitializedBlock("dummy", segmentBlock.getEnd().add(1), zeroPadLen, "Loadable segment", NOACCESS, false);
 				segmentBlock = ctx.memory.join(segmentBlock, padBlk);
 			}
 		} else if (Phdr.p_memsz > 0) {
 			//It is possible that the RW segment contains only .bss (no uninitialized static data).
 			//In this case, simply create a zero-initialized segment.
-			
-			segmentBlock = createZeroInitializedBlock(segmentName, segmentLoadAddress, Phdr.p_memsz, "Zero-initialized segment", PhdrFlagsToMemPerms(Phdr.p_flags), false);			
+
+			segmentBlock = createZeroInitializedBlock(segmentName, segmentLoadAddress, Phdr.p_memsz, "Zero-initialized segment", PhdrFlagsToMemPerms(Phdr.p_flags), false);
 		} else {
 			ctx.logf("Skipped zero-length segment #%d (PT_LOAD segment, file offset 0x%X, flags 0x%X)", index, Phdr.p_offset, Phdr.p_flags);
 		}
@@ -329,21 +329,21 @@ public class ArmElfPrxLoader extends AbstractLibrarySupportLoader {
 	//Initializes Phdr.userData to the corresponding MemoryBlock object.
 	private void loadSegments() throws Exception {
 		ctx.startCountableTask("Loading program segments...", ctx.elfEhdr.e_phnum);
-		
+
 		int numLoadedPTLOADSegments = 0;
 		for (int i = 0; i < ctx.elfEhdr.e_phnum; i++, ctx.incrementTaskProgress()) {
 			ElfPhdr Phdr = ctx.elfEhdr.programHeaders[i];
-	
+
 			if (Phdr.p_type == ElfProgramHeaderConstants.PT_NULL)
 				continue;
-			
+
 			if (Phdr.p_type == ElfProgramHeaderConstants.PT_LOAD) {
 				if (importPTLOADSegment(Phdr, i) != null) {
 					numLoadedPTLOADSegments++;
 				}
 			} else if (
 					Phdr.p_type == ElfPhdr.PT_SCE_RELA ||
-					Phdr.p_type == ElfPhdr.PT_SCE_COMMENT || 
+					Phdr.p_type == ElfPhdr.PT_SCE_COMMENT ||
 					Phdr.p_type == ElfPhdr.PT_SCE_VERSION ||
 					Phdr.p_type == ElfPhdr.PT_ARM_UNWIND   ||
 					Phdr.p_type == ElfPhdr.PT_SCE_ARMRELA) {
@@ -379,7 +379,7 @@ public class ArmElfPrxLoader extends AbstractLibrarySupportLoader {
 					break;
 				}
 				}
-				
+
 				//Check that the segment is not empty and belongs in the file
 				if (Phdr.p_filesz <= 0) {
 					ctx.logf("Skipped zero-length segment #%d (%s)", i, comment);
@@ -392,9 +392,9 @@ public class ArmElfPrxLoader extends AbstractLibrarySupportLoader {
 				ctx.logf("Skipped segment #%d (unknown segment type 0x%X)", i, Phdr.p_type);
 			}
 		}
-		
+
 		ctx.setMonitorMessage("Post-processing segments...");
-		
+
 		//Check if PT_LOAD segments are candidate for '.text'/'.data' naming
 		if (numLoadedPTLOADSegments == 1 || numLoadedPTLOADSegments == 2) {
 			ElfPhdr textSegment = null, dataSegment = null;
@@ -409,7 +409,7 @@ public class ArmElfPrxLoader extends AbstractLibrarySupportLoader {
 					}
 				}
 			}
-			
+
 			if (textSegment != null && (numLoadedPTLOADSegments == 1 || dataSegment != null)) {
 				((MemoryBlock)textSegment.userData).setName(".text");
 				if (dataSegment != null) {
@@ -425,7 +425,7 @@ public class ArmElfPrxLoader extends AbstractLibrarySupportLoader {
 		if (loc == null) {
 			throw new UnsupportedElfException("Cannot find SceModuleInfo location");
 		}
-		
+
 		//Read SceModuleInfo
 		Address modInfoSegmentBase = getSegmentStartAddress(ctx.elfEhdr.programHeaders[loc.segmentIndex]);
 		Address modInfoAddr = modInfoSegmentBase.add(loc.segmentOffset);
@@ -437,13 +437,13 @@ public class ArmElfPrxLoader extends AbstractLibrarySupportLoader {
 		//Markup __sce_moduleinfo and add in module namespace
 		DataType moduleAttributes = SELFConstants.createModuleAttributesDataType(ctx.program.getDataTypeManager(), Datatypes.SCE_TYPES_CATPATH);
 		ctx.createLabeledDataInNamespace(modInfoAddr, ctx.moduleNamespace, "__sce_moduleinfo", modInfo.toDataType(moduleAttributes));
-		
+
 		//Parse imports if available
 		if (modInfo.stub_top != modInfo.stub_end) {
 			//NOTE: it is not valid to create an address from libstub_btm
 			//because it may not belong in the address space covered by the ELF.
 			Address firstLibstub = modInfoSegmentBase.add(modInfo.stub_top);
-			
+
 			//Read-ahead the size of the libstub used in this SELF.
 			//Since mixing different libstub structures is illegal,
 			//this allows us to know how many of them there are.
@@ -453,9 +453,9 @@ public class ArmElfPrxLoader extends AbstractLibrarySupportLoader {
 				throw new MalformedElfException("Libstub block size is not a multiple of the libstub size!");
 			}
 			final int numLibstubs = (int)(libstubBlockSize / libstubSize);
-			
+
 			ctx.startCountableTask("Processing imports...", numLibstubs);
-			
+
 			for (int i = 0; i < numLibstubs; i++, ctx.incrementTaskProgress()) {
 				Address currentLibstub = firstLibstub.add(i * libstubSize);
 				BinaryReader libstubReader = ctx.getBinaryReader(currentLibstub);
@@ -473,17 +473,17 @@ public class ArmElfPrxLoader extends AbstractLibrarySupportLoader {
 				default:
 					throw new MalformedElfException(String.format("Invalid LibraryStub size 0x%X", libstubSize));
 				}
-				
+
 				libstub.process(ctx, currentLibstub);
 			}
-			
+
 			ctx.endCountableTask();
 		}
-		
+
 		//Parse exports if available
 		if (modInfo.ent_top != modInfo.ent_end) {
 			boolean hasSeenMAINEXPORT = false;
-			
+
 			//NOTE: it is not valid to create an address from libent_btm
 			//because it may not belong in the address space covered by the ELF.
 			final Address firstLibent = modInfoSegmentBase.add(modInfo.ent_top);
@@ -497,9 +497,9 @@ public class ArmElfPrxLoader extends AbstractLibrarySupportLoader {
 				throw new MalformedElfException("Libent block size is not a multiple of the libent size!");
 			}
 			final int numLibents = (int)(libentBlockSize / libentSize);
-			
+
 			ctx.startCountableTask("Processing exports...", numLibents);
-			
+
 			for (int i = 0; i < numLibents; i++, ctx.incrementTaskProgress()) {
 				Address currentLibent = firstLibent.add(i * libentSize);
 				BinaryReader libentReader = ctx.getBinaryReader(currentLibent);
@@ -514,47 +514,47 @@ public class ArmElfPrxLoader extends AbstractLibrarySupportLoader {
 				default:
 					throw new MalformedElfException(String.format("Invalid LibraryEntry size 0x%X", libentSize));
 				}
-				
+
 				if ((libent.getAttributes() & SELFConstants.SCE_LIBRARY_ATTR_MAIN_EXPORT) != 0) {
 					if (hasSeenMAINEXPORT) {
 						throw new MalformedElfException("More than one MAINEXPORT library.");
 					}
 					hasSeenMAINEXPORT = true;
 				}
-				
+
 				libent.process(ctx, currentLibent);
 			}
-			
+
 			ctx.endCountableTask();
-			
+
 			if (!hasSeenMAINEXPORT) {
 				throw new MalformedElfException("No MAINEXPORT library.");
 			}
 		}
-		
+
 		ctx.setMonitorMessage("Processing SceModuleInfo...");
-		
+
 		//Markup exidx, extab and TLS
 		if (modInfo.arm_exidx_top < modInfo.arm_exidx_end) {
 			final int size = (int)(modInfo.arm_exidx_end - modInfo.arm_exidx_top);
 			if (size < 0) {
 				throw new MalformedElfException("exidx overflow");
 			}
-			
+
 			Address exidx = modInfoSegmentBase.add(modInfo.arm_exidx_top);
 			ctx.createLabeledDataInNamespace(exidx, ctx.moduleNamespace, "exidx", Datatypes.makeArray(ByteDataType.dataType, size));
 		}
-		
+
 		if (modInfo.arm_extab_top < modInfo.arm_extab_btm) {
 			final int size = (int)(modInfo.arm_extab_btm - modInfo.arm_extab_top);
 			if (size < 0) {
 				throw new MalformedElfException("extab overflow");
 			}
-			
+
 			Address extab = modInfoSegmentBase.add(modInfo.arm_extab_top);
 			ctx.createLabeledDataInNamespace(extab, ctx.moduleNamespace, "extab", Datatypes.makeArray(ByteDataType.dataType, size));
 		}
-		
+
 		if (modInfo.tls_top != 0 && modInfo.tls_memsz != 0) {
 			Address tls_start = modInfoSegmentBase.add(modInfo.tls_top);
 			Address tls_end = tls_start.add(modInfo.tls_memsz - 1);
@@ -566,7 +566,7 @@ public class ArmElfPrxLoader extends AbstractLibrarySupportLoader {
 				ctx.logf("Could not markup TLS data due to a data conflict");
 			}
 		}
-		
+
 		//Create a property map that indicates this is a Vita ELF, and can be used by analyzers
 		//and scripts to locate the SceModuleInfo structure and its segment base trivially.
 		try {
@@ -581,7 +581,7 @@ public class ArmElfPrxLoader extends AbstractLibrarySupportLoader {
 	}
 
 	/* -------------- Utility functions -------------- */
-	
+
 	//On any Exception, returns null and logs to MessageLog.
 	private Data createDataFromFileInOtherAS(String blockName, String comment, long fileOffset, DataType dt) throws CancelledException {
 		ctx.monitor.checkCancelled();
@@ -595,25 +595,25 @@ public class ArmElfPrxLoader extends AbstractLibrarySupportLoader {
 			return null;
 		}
 	}
-	
+
 	private MemoryBlock createZeroInitializedBlock(String name, Address start,
 			long length, String comment, int perms, boolean isOverlay) throws CancelledException {
 		ctx.monitor.checkCancelled();
 		boolean r = (perms & PF_R) != 0,
 				w = (perms & PF_W) != 0,
 				x = (perms & PF_X) != 0;
-		
+
 		return MemoryBlockUtils.createInitializedBlock(ctx.program, isOverlay, name, start,
 				length, comment, "", r, w, x, ctx.logger);
 	}
-	
+
 	private MemoryBlock createFileBytesBlock(String name, Address start, long fileOffset,
 			long length, String comment, int perms, boolean isOverlay) throws AddressOverflowException, CancelledException {
 		ctx.monitor.checkCancelled();
 		boolean r = (perms & PF_R) != 0,
 				w = (perms & PF_W) != 0,
 				x = (perms & PF_X) != 0;
-		
+
 		return MemoryBlockUtils.createInitializedBlock(ctx.program, isOverlay, name, start,
 				fileBytes, fileOffset, length, comment, this.getName(), r, w, x, ctx.logger);
 
@@ -622,40 +622,40 @@ public class ArmElfPrxLoader extends AbstractLibrarySupportLoader {
 	private static Address getSegmentStartAddress(ElfPhdr segment) {
 		return ((MemoryBlock)segment.userData).getStart();
 	}
-	
+
 	private static int PhdrFlagsToMemPerms(long p_flags) {
 		return (int)(p_flags & (PF_R | PF_W | PF_X));
 	}
 
 	/* Exported utility functions */
-	
+
 	public static int getVarImportBlockVA(List<Option> options) {
 		return OptionUtils.getOption(VARIMPORT_BLOCK_ADDRESS_OPTNAME, options, 0xF0000000L).intValue();
 	}
-	
+
 	public static int getVarImportBlockSize(List<Option> options) {
 		return OptionUtils.getOption(VARIMPORT_BLOCK_SIZE_OPTNAME, options, 0x10000000L).intValue();
 	}
-	
+
 	public static int getVarImportSize(List<Option> options) {
 		return OptionUtils.getOption(VARIMPORT_SIZE_OPTNAME, options, 0x1000L).intValue();
 	}
-	
+
 	public static boolean isArmExecutable(Program program) {
 		return (program.getUsrPropertyManager().getVoidPropertyMap(MODULE_INFO_LOCATOR_USRPROPNAME) != null);
 	}
-	
+
 	public static Address getModuleInfoSegmentBaseAddressFromVPM(Program program) {
 		//By definition, the segment base is <= SceModuleInfo address, thus it's first.
 		return program.getUsrPropertyManager().getVoidPropertyMap(MODULE_INFO_LOCATOR_USRPROPNAME).getFirstPropertyAddress();
 	}
-	
+
 	public static Address getModuleInfoAddressFromVPM(Program program) {
 		//Since the segment base is first, the SceModuleInfo must be second i.e. next after the first.
 		VoidPropertyMap vpm = program.getUsrPropertyManager().getVoidPropertyMap(MODULE_INFO_LOCATOR_USRPROPNAME);
 		return vpm.getNextPropertyAddress(vpm.getFirstPropertyAddress());
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	public static ObjectPropertyMap<ImportExportProperty> getImportExportPropertyMap(Program program) {
 		return (ObjectPropertyMap<ImportExportProperty>)program.getUsrPropertyManager().getObjectPropertyMap(IMPORTEXPORT_LOCATOR_USRPROPNAME);

--- a/src/main/java/vitaloaderredux/loader/ArmElfPrxLoaderContext.java
+++ b/src/main/java/vitaloaderredux/loader/ArmElfPrxLoaderContext.java
@@ -31,24 +31,24 @@ public class ArmElfPrxLoaderContext extends ProgramProcessingHelper {
 	public final long fileSize;
 	private final LibraryToModuleDatabase ln2fnDB;
 	private final ObjectPropertyMap<ImportExportProperty> importExportMap;
-	
+
 	static public final String FILE_KIND_APP = "Application (.self)";
 	static public final String FILE_KIND_USERMOD = "User module (.suprx)";
 	static public final String FILE_KIND_KERNMOD = "Kernel module (.skprx)";
-	
+
 	//Store in here to allow users to save some typing on user side.
 	static public final ImportExportProperty.IEType IETYPE_IMPORT = ImportExportProperty.IEType.IMPORT;
 	static public final ImportExportProperty.IEType IETYPE_EXPORT = ImportExportProperty.IEType.EXPORT;
 	static public final ImportExportProperty.IEKind IEKIND_FUNC = ImportExportProperty.IEKind.FUNCTION;
 	static public final ImportExportProperty.IEKind IEKIND_VAR = ImportExportProperty.IEKind.VARIABLE;
 	static public final ImportExportProperty.IEKind IEKIND_TLSVAR = ImportExportProperty.IEKind.TLS_VARIABLE;
-	
+
 	//To be filled up later on.
 	public Namespace moduleNamespace = null;
 	private String processParamSDKVersion = null;
 	private String moduleSDKVersion = null;
 	private String fileKind = null;
-	
+
 	public ArmElfPrxLoaderContext(Program p, ElfEhdr e, TaskMonitor m, MessageLog ml, long byteProviderLength, List<Option> options) throws Exception {
 		super(p); monitor = m; logger = ml; elfEhdr = e; fileSize = byteProviderLength;
 
@@ -56,16 +56,16 @@ public class ArmElfPrxLoaderContext extends ProgramProcessingHelper {
 		ln2fnDB = new LibraryToModuleDatabase(logger);
 		importExportMap = usrPropMgr.createObjectPropertyMap(ArmElfPrxLoader.IMPORTEXPORT_LOCATOR_USRPROPNAME, ImportExportProperty.class);
 		libraryAttributesType = SELFConstants.createLibraryAttributesDataType(program.getDataTypeManager(), Datatypes.SCE_TYPES_CATPATH);
-		
+
 		//Initialize the relocator
 		relocator = new ArmRelocator(this, ArmElfPrxLoader.getVarImportBlockVA(options),
 				ArmElfPrxLoader.getVarImportBlockSize(options), ArmElfPrxLoader.getVarImportSize(options));
 	}
-	
+
 	public void logf(String format, Object...args) {
 		logger.appendMsg(String.format(format, args));
 	}
-	
+
 	private String makeSDKVersionString(int sdkVersion) {
 		//SDK version is an hexadecimal number that contains three fields.
 		// 0x03600011 can be broken down into
@@ -73,17 +73,17 @@ public class ArmElfPrxLoaderContext extends ProgramProcessingHelper {
 		//This should be displayed as 3.600.011
 		return String.format("%X.%03X.%03X", sdkVersion >>> 24, (sdkVersion >>> 12) & 0xFFF, sdkVersion & 0xFFF);
 	}
-	
+
 	public String getModuleSDKVersion() { return moduleSDKVersion; }
 	public void setModuleSDKVersion(int sdkVersion) {
 		moduleSDKVersion = makeSDKVersionString(sdkVersion);
 	}
-	
+
 	public String getProcessParamSDKVersion() { return processParamSDKVersion; }
 	public void setProcessParamSDKVersion(int sdkVersion) {
 		processParamSDKVersion = makeSDKVersionString(sdkVersion);
 	}
-	
+
 	public String getFileKind() { return fileKind; }
 	public void setFileKind(String kind) {
 		if (fileKind != null) {
@@ -92,16 +92,16 @@ public class ArmElfPrxLoaderContext extends ProgramProcessingHelper {
 		}
 		fileKind = kind;
 	}
-	
+
 	public String modFileNameFromLibraryName(String libraryName) {
 		return ln2fnDB.lookup(libraryName);
 	}
-	
+
 	public void addImportExportEntry(Address addr, String libraryName, int nid, ImportExportProperty.IEType type, ImportExportProperty.IEKind kind) {
 		ImportExportProperty iep = new ImportExportProperty(libraryName, nid, type, kind);
 		importExportMap.add(addr, iep);
 	}
-	
+
 	private Data _generic_markup(int va, String name, DataType dt) throws Exception {
 		monitor.checkCancelled();
 		if (va != 0) {
@@ -109,19 +109,19 @@ public class ArmElfPrxLoaderContext extends ProgramProcessingHelper {
 		}
 		return null;
 	}
-	
+
 	public Data markupString(int va, String name) throws Exception {
 		return _generic_markup(va, name, TerminatedStringDataType.dataType);
 	}
-	
+
 	public Data markupS32(int va, String name) throws Exception {
 		return _generic_markup(va, name, Datatypes.s32);
 	}
-	
+
 	public Data markupU32(int va, String name) throws Exception {
 		return _generic_markup(va, name, Datatypes.u32);
 	}
-	
+
 	public void startCountableTask(String taskName, int numItems) throws CancelledException {
 		monitor.checkCancelled();
 		monitor.setShowProgressValue(false);
@@ -130,21 +130,21 @@ public class ArmElfPrxLoaderContext extends ProgramProcessingHelper {
 		monitor.setMessage(taskName);
 		monitor.setShowProgressValue(true);
 	}
-	
+
 	public void incrementTaskProgress() throws CancelledException {
 		monitor.checkCancelled();
 		monitor.incrementProgress(1);
 	}
-	
+
 	public void endCountableTask() throws CancelledException {
 		monitor.checkCancelled();
 		monitor.setShowProgressValue(false);
 	}
-	
+
 	public void setMonitorMessage(String msg) throws CancelledException {
 		monitor.checkCancelled();
 		monitor.setShowProgressValue(false);
 		monitor.setMessage(msg);
 	}
-	
+
 }

--- a/src/main/java/vitaloaderredux/misc/BitfieldReader.java
+++ b/src/main/java/vitaloaderredux/misc/BitfieldReader.java
@@ -4,47 +4,47 @@ public class BitfieldReader {
 	private int currentIndex = 0;
 	private final int maxIndex;
 	private final long data;
-	
+
 	public int bitsConsumed() {
 		return currentIndex;
 	}
-	
+
 	public boolean isFullyConsumed() {
 		return bitsConsumed() == maxIndex;
 	}
-	
+
 	public BitfieldReader(short s) {
 		data = s;
 		maxIndex = 16;
 	}
-	
+
 	public BitfieldReader(int i) {
 		data = i;
 		maxIndex = 32;
 	}
-	
+
 	public BitfieldReader(long l) {
 		data = l;
 		maxIndex = 64;
 	}
-	
+
 	public long consumeLong(int num_bits) {
 		if (currentIndex + num_bits > maxIndex) {
 			throw new IllegalArgumentException("Tried consuming " + num_bits + " bits but only " + (maxIndex - currentIndex) + " are available");
 		}
 		final int shift = currentIndex;
 		final long mask = (1L << num_bits) - 1;
-		
+
 		currentIndex += num_bits;
-		
+
 		return (data >>> shift) & mask;
 	}
-	
+
 	//Same as consume, but sign-extends the value to 32 bits.
 	public int consumeSEXT(int num_bits) {
 		final int biggest = (1 << num_bits) - 1;
 		final int sign = (1 << (num_bits - 1));
-		
+
 		int val = consume(num_bits);
 		if ((val & sign) != 0) {
 			//Set all upper bits (outside of the range representable in num_bits bits)
@@ -52,25 +52,25 @@ public class BitfieldReader {
 		}
 		return val;
 	}
-	
+
 	public int consume(int num_bits) {
 		if ((currentIndex + num_bits) > maxIndex) {
 			throw new IllegalArgumentException("Tried consuming " + num_bits + " bits but only " + (maxIndex - currentIndex) + " are available");
 		}
-		
+
 		if (num_bits > 32) {
 			throw new IllegalArgumentException("Tried consuming " + num_bits + " into a 32-bit integer");
 		}
-		
+
 		return (int)consumeLong(num_bits);
 	}
-	
+
 	public void assertFullConsumption(String msg) {
 		if (!isFullyConsumed()) {
 			throw new RuntimeException(msg + ": didn't consume all " + maxIndex + " bits available");
 		}
 	}
-	
+
 	public void assertConsumption(String msg, int num) {
 		if (currentIndex != num) {
 			throw new RuntimeException(msg + ": consumed " + bitsConsumed() + " bits instead of " + num);

--- a/src/main/java/vitaloaderredux/misc/Datatypes.java
+++ b/src/main/java/vitaloaderredux/misc/Datatypes.java
@@ -25,9 +25,9 @@ public class Datatypes {
 	static public final CategoryPath ELF_CATPATH = new CategoryPath("/ELF");
 	static public final CategoryPath SCE_TYPES_CATPATH = new CategoryPath("/SCE");
 	static public final CategoryPath SCE_LIBC_TYPES_CATPATH = new CategoryPath(SCE_TYPES_CATPATH, "SceLibc");
-	
+
 	static public final DataType VOID = VoidDataType.dataType;
-	
+
 	static public final DataType char8 = CharDataType.dataType;
 
 	static public final DataType u8 = ByteDataType.dataType;
@@ -38,46 +38,46 @@ public class Datatypes {
 	static public final DataType s32 = IntegerDataType.dataType;
 	static public final DataType u64 = UnsignedLongLongDataType.dataType;
 	static public final DataType s64 = LongLongDataType.dataType;
-	
+
 	static { assert(u64.getLength() == 8); assert(s64.getLength() == 8); }
 
 	static public final DataType ptr = Pointer32DataType.dataType;
 	static public final DataType u32ptr = new Pointer32DataType(u32);
 	static public final DataType ptr_to_ptr = new Pointer32DataType(ptr);
 	static public final DataType stringptr = new Pointer32DataType(TerminatedStringDataType.dataType);
-	
+
 	static public final DataType makeArray(DataType dt, int n) {
 		return new ArrayDataType(dt, n, 0);
 	}
-	
+
 	static public class FunctionArgument {
 		public final DataType type;
 		public final String name;
-		
+
 		public FunctionArgument(DataType type, String name) {
 			this.name = name;
 			this.type = type;
 		}
 	}
-	
+
 	static private ParameterDefinition[] __funcargs_to_pdef(FunctionArgument[] arguments) {
 		ParameterDefinition[] pdef = new ParameterDefinition[arguments.length];
 		for (int i = 0; i < arguments.length; i++) {
 			pdef[i] = new ParameterDefinitionImpl(arguments[i].name, arguments[i].type, null);
 		}
-		
+
 		return pdef;
 	}
-	
+
 	static public FunctionDefinitionDataType createFunctionDT(CategoryPath catPath, DataType returnType, String name, FunctionArgument[] arguments) {
 		FunctionDefinitionDataType fdt = new FunctionDefinitionDataType(catPath, name);
 		fdt.setReturnType(returnType);
 		if (arguments != null) {
 			fdt.setArguments(__funcargs_to_pdef(arguments));
 		}
-		return fdt;	
+		return fdt;
 	}
-	
+
 	@SafeVarargs
 	static public FunctionDefinitionDataType createFunctionDT(CategoryPath catPath, DataType returnType, String name, Map.Entry<DataType, String>... args) {
 		FunctionArgument[] arguments = null;
@@ -88,10 +88,10 @@ public class Datatypes {
 				arguments[i++] = new FunctionArgument(arg.getKey(), arg.getValue());
 			}
 		}
-		
+
 		return createFunctionDT(catPath, returnType, name, arguments);
 	}
-	
+
 	static public FunctionDefinitionDataType createFunctionDT(CategoryPath catPath, DataType returnType, String name, FunctionArgument argument) {
 		return createFunctionDT(catPath, returnType, name, new FunctionArgument[] {argument});
 	}

--- a/src/main/java/vitaloaderredux/misc/HexOption.java
+++ b/src/main/java/vitaloaderredux/misc/HexOption.java
@@ -7,26 +7,26 @@ import docking.widgets.textfield.IntegerTextField;
 import ghidra.app.util.Option;
 
 /**
- * 
+ *
  * Option for an Hexadecimal integer
  */
 public class HexOption extends Option {
 		public HexOption(String name, long value) {
 			this(null, name, value);
 		}
-		
+
 		public HexOption(String group, String name, long value) {
 			this(name, value, null, group);
 		}
-		
+
 		public HexOption(String group, String name, long value, String arg) {
 			this(name, value, group, arg);
 		}
-		
+
 		public HexOption(String name, long value, String arg, String group) {
 			super(name, Long.class, value, arg, group);
 		}
-		
+
 		@Override
 		public Component getCustomEditorComponent() {
 			IntegerTextField field = new IntegerTextField();
@@ -46,11 +46,11 @@ public class HexOption extends Option {
 			});
 			return field.getComponent();
 		}
-		
+
 		@Override
 		public Option copy() {
 			return new HexOption(getName(), (long)getValue(), getArg(), getGroup());
 		}
-		
+
 
 	}

--- a/src/main/java/vitaloaderredux/misc/ImportExportProperty.java
+++ b/src/main/java/vitaloaderredux/misc/ImportExportProperty.java
@@ -59,9 +59,9 @@ public class ImportExportProperty implements Saveable, ExtensionPoint {
 	public int getNID() { return NID; }
 	public IEType getType() { return type; }
 	public IEKind getKind() { return kind; }
-	
+
 	public ImportExportProperty() {}
-	
+
 	//As an optimization, we may want to store the VA of the library name instead of the name itself.
 	//Although, even in the worse scenario of ~400 imports/exports per file, knowing each library name
 	//takes up to 27 bytes, this shouldn't consume more than a few KBs.

--- a/src/main/java/vitaloaderredux/misc/Utils.java
+++ b/src/main/java/vitaloaderredux/misc/Utils.java
@@ -6,38 +6,38 @@ import ghidra.app.util.bin.BinaryReader;
 import ghidra.program.model.data.StructureDataType;
 
 public class Utils {
-	
+
 	static public void assertBRSize(String msg, BinaryReader reader, int expectedSize) {
 		if (reader.getPointerIndex() != expectedSize) {
 			throw new RuntimeException(msg + ": invalid pointer index " + reader.getPointerIndex() + " != " + expectedSize);
 		}
 	}
-	
+
 	static public void assertStructureSize(StructureDataType dt, int expectedSize) {
 		if (dt.getLength() != expectedSize) {
 			throw new RuntimeException(dt.getName() + ": invalid size " + dt.getLength() + " != " + expectedSize);
 		}
 	}
-	
+
 	static public String getSystematicName(String libraryName, int thingNID) {
 		return String.format("%s_%08X", libraryName, thingNID);
 	}
-	
+
 	static private final Pattern NIDPattern = Pattern.compile("[0-9A-F]{8}");
 	static public boolean isSystematicName(String name) {
 		//has '_' character
 		int underscore = name.indexOf('_');
 		if (underscore == -1)
 			return false;
-		
+
 		//has a single '_'
 		if (underscore != name.lastIndexOf('_'))
 			return false;
-		
+
 		//has stuff after the '_'
 		if (underscore == name.length() - 1)
 			return false;
-		
+
 		//stuff after the '_' is a valid NID
 		return NIDPattern.matcher(name.substring(underscore + 1)).matches();
 	}
@@ -46,126 +46,126 @@ public class Utils {
 		//Can't fit more than 4GiB in 32-bit
 		String[] suffixes = { "B", "KiB", "MiB", "GiB" };
 		int selected_suffix = 0;
-		
+
 		while (size >= 1024) {
 			selected_suffix++;
 			size /= 1024;
 		}
-		
+
 		return String.format("%d%s", size, suffixes[selected_suffix]);
 	}
-	
+
 	static public String prettifyPriority(int prio) {
 		final int SCE_KERNEL_DEFAULT_PRIORITY = 0x10000100;
 		final int SCE_KERNEL_DEFAULT_PRIORITY_bit = 0x10000000;
 		if ((prio & SCE_KERNEL_DEFAULT_PRIORITY_bit) != 0) {
 			if (prio == SCE_KERNEL_DEFAULT_PRIORITY)
 				return "SCE_KERNEL_DEFAULT_PRIORITY (160)";
-			
+
 			//SCE_KERNEL_DEFAULT_PRIORITY is defined as 0x1000_0100.
 			//It can be used to specify priorities by doing (SCE_KERNEL_DEFAULT_PRIORITY - 10).
 			//Internally, the default priority is converted to 160 (TODO: even for kernel?)
-			
+
 			//(1) Find offset from default value.
 			//Since the minimal priority is 255 and the maximal is 0 (or 1?),
 			//only the bottom 9 bits are significant for this task.
 			//TODO: how does SCE do this?
 			final int offset = (prio & 0x3FF) - 0x100; //Extract the X in (SCE_KERNEL_DEFAULT_PRIORITY + X)
 			final int realPriority = 160 + offset;     //Use +, not -, because we extracted the value with its sign.
-			
+
 			final char sign = (offset < 0) ? '-' : '+';
 			final int absOffset = Math.abs(offset);
-			
+
 			return String.format("SCE_KERNEL_DEFAULT_PRIORITY %c %d (%d)", sign, absOffset, realPriority);
 		}
-		
+
 		return String.format("%d", prio);
 	}
-	
+
 	static public String prettifyCpuAffinityMask(int affinityMask) {
 		String userSuffix = "";
 		if ((affinityMask & 0xF0000) != 0) {
 			affinityMask >>= 16;
 			userSuffix = "USER_";
 		}
-		
+
 		if (affinityMask == 0x7) {
 			return "SCE_KERNEL_CPU_MASK_" + userSuffix + "ALL";
 		}
 		if (affinityMask == 0xF) {
 			return "SCE_KERNEL_CPU_MASK_" + userSuffix + "QUAD";
 		}
-		
+
 		String result = "";
 		int num_bits = 0;
 		if ((affinityMask & 0x8) != 0) {
 			num_bits++;
 			result += "SCE_KERNEL_CPU_MASK_" + userSuffix + "3";
 		}
-		
+
 		if ((affinityMask & 0x4) != 0) {
 			if (num_bits != 0)
 				result += " | ";
 			num_bits++;
 			result += "SCE_KERNEL_CPU_MASK_" + userSuffix + "2";
 		}
-		
+
 		if ((affinityMask & 0x4) != 0) {
 			if (num_bits != 0)
 				result += " | ";
 			num_bits++;
 			result += "SCE_KERNEL_CPU_MASK_" + userSuffix + "2";
 		}
-		
+
 		if ((affinityMask & 0x2) != 0) {
 			if (num_bits != 0)
 				result += " | ";
 			num_bits++;
 			result += "SCE_KERNEL_CPU_MASK_" + userSuffix + "1";
 		}
-		
+
 		if ((affinityMask & 0x1) != 0) {
 			if (num_bits != 0)
 				result += " | ";
 			num_bits++;
 			result += "SCE_KERNEL_CPU_MASK_" + userSuffix + "0";
 		}
-		
+
 		if (num_bits > 1) {
 			result = "(" + result + ")";
 		}
 		return result;
 	}
-	
+
 	static public String prettifyInhibitBitflag(int inhibitBitflag) {
 		String inhibit = "";
 		if ((inhibitBitflag & 0x10000) != 0)
 			inhibit += "libc.suprx\n";
-		
+
 		if ((inhibitBitflag & 0x20000) != 0)
 			inhibit += "libdbg.suprx\n";
-		
+
 		if ((inhibitBitflag & 0x80000) != 0)
 			inhibit += "libshellsvc.suprx\n";
-		
+
 		if ((inhibitBitflag & 0x100000) != 0)
 			inhibit += "libcdlg.suprx\n";
-		
+
 		if ((inhibitBitflag & 0x200000) != 0)
 			inhibit += "libfios2.suprx\n";
-		
+
 		if ((inhibitBitflag & 0x400000) != 0)
 			inhibit += "apputil.suprx\n";
-		
+
 		if ((inhibitBitflag & 0x800000) != 0)
 			inhibit += "libSceFt2.suprx\n";
-		
+
 		if ((inhibitBitflag & 0x1000000) != 0)
 			inhibit += "libpvf.suprx\n";
 
 		if ((inhibitBitflag & 0x2000000) != 0)
 			inhibit += "libperf.suprx\n";
-		
+
 		if (inhibit == "") {
 			return "No inhibited modules";
 		} else {
@@ -173,5 +173,5 @@ public class Utils {
 			return "Inhibited modules:\n" + inhibit.stripTrailing();
 		}
 	}
-	
+
 }

--- a/src/main/java/vitaloaderredux/misc/sdt_probedesc_t.java
+++ b/src/main/java/vitaloaderredux/misc/sdt_probedesc_t.java
@@ -24,7 +24,7 @@ import vitaloaderredux.loader.ArmElfPrxLoaderContext;
 public class sdt_probedesc_t {
 	static public final String STRUCTURE_NAME = "sdt_probedesc_t";
 	static private final String PROBE_BOOKMARK_CATEGORY_NAME = "Static Probe Instrumentation Point";
-	
+
 	public final int sdpd_id;
 	public final int sdpd_provider; // pointer
 	public final int sdpd_name; // pointer
@@ -120,7 +120,7 @@ public class sdt_probedesc_t {
 			String comment = makePlateComment();
 			comment += "Probe " + name + " helper function";
 			Function f = ctx.markupFunction(providerName + probeName + "_" + name + "_fn", va, comment);
-			
+
 			// If only you could do Function.setSignature(FunctionDefinitionDataType dt)...
 			Variable[] arg = new Variable[1];
 			arg[0] = new ParameterImpl("desc", new Pointer32DataType(this.toDataType()), ctx.program);
@@ -168,7 +168,7 @@ public class sdt_probedesc_t {
 					instrumentationPointAddr, BookmarkType.ANALYSIS, PROBE_BOOKMARK_CATEGORY_NAME,
 					providerName + probeName + " instrumentation point"
 			);
-			
+
 			String comment = makePlateComment();
 			comment += "Probe instrumentation point";
 			ctx.listing.setComment(instrumentationPointAddr, CodeUnit.PLATE_COMMENT, comment);

--- a/src/main/java/vitaloaderredux/scetypes/ILibstub.java
+++ b/src/main/java/vitaloaderredux/scetypes/ILibstub.java
@@ -27,7 +27,7 @@ public abstract class ILibstub {
 
 	protected final DataType _getCommonDataType(DataType libAttrType, boolean newname) {
 		final DataType ubyte = Datatypes.u8, ushort = Datatypes.u16;
-				
+
 		StructureDataType common = new StructureDataType(Datatypes.SCE_TYPES_CATPATH, "sceKernelLibraryStubTable_ppu_common", 0);
 		common.add(ubyte, "structsize", "Size of this structure");
 		common.add(Datatypes.makeArray(ubyte, 1), "reserved1", "");
@@ -37,14 +37,14 @@ public abstract class ILibstub {
 		common.add(ushort, "nvar", "Number of variables imported from this library");
 		common.add(ushort, "ntlsvar", "Number of TLS variables imported from this library");
 		common.add(Datatypes.makeArray(ubyte, 4), "reserved2", "");
-		
+
 		if (!newname) {
 			return common;
 		}
-		
+
 		return new TypedefDataType(Datatypes.SCE_TYPES_CATPATH, "sceKernelLibraryStubTable_prx2_common", common);
 	}
-	
+
 	protected int version;
 	protected int attribute;
 
@@ -60,7 +60,7 @@ public abstract class ILibstub {
 
 	protected int var_nidtable;
 	protected int var_table;
-	
+
 	protected int tls_nidtable;
 	protected int tls_table;
 
@@ -154,12 +154,12 @@ public abstract class ILibstub {
 		Function importStub = ctx.getImportFunction(modFileName, funcName);
 		func.setThunkedFunction(importStub); // Mark as imported function
 		ctx.addImportExportEntry(funcAddr, libraryName, nid, ArmElfPrxLoaderContext.IETYPE_IMPORT, ArmElfPrxLoaderContext.IEKIND_FUNC);
-		
+
 		// Process function relocations if any exist
 		final int funcRelaVA = ctx.memory.getInt(funcAddr.add(3*4));
 		if (funcRelaVA != 0) {
 			ctx.createData(funcAddr.add(3*4), Datatypes.ptr);
-			
+
 			final Address relaAddr = ctx.getAddressInDefaultAS(funcRelaVA);
 			ctx.listing.setComment(relaAddr, CodeUnit.PLATE_COMMENT, String.format("Relocation table for %s @ 0x%08X", funcName, va));
 			ctx.relocator.processReftable(relaAddr, funcAddr);
@@ -173,11 +173,11 @@ public abstract class ILibstub {
 
 		//Allocate import variable slot and perform relocation towards it
 		Address importVarAddr = ctx.relocator.allocateImportVariableSlot(libraryName, nid, tls);
-		
+
 		//Markup the table and add comment to table and variable
 		ctx.listing.setComment(relaAddr, CodeUnit.PLATE_COMMENT, String.format("Relocation table for %s @ 0x%08X", varName, importVarAddr.getOffset()));
-		
-		String comment = generateImportPlateComment(tls ? "TLS Variable" : "Variable", modFileName, nid);		
+
+		String comment = generateImportPlateComment(tls ? "TLS Variable" : "Variable", modFileName, nid);
 		ctx.listing.setComment(importVarAddr, CodeUnit.PLATE_COMMENT, comment);
 		ctx.relocator.processReftable(relaAddr, importVarAddr);
 	}
@@ -185,7 +185,7 @@ public abstract class ILibstub {
 	private void markupAndProcessTable(int nidTableVA, int entryTableVA, int numElements, String kind,
 			TableProcessingCallback callback) throws Exception {
 		ctx.monitor.checkCancelled();
-		
+
 		Address nidTblAddr = ctx.getAddressInDefaultAS(nidTableVA);
 		Address entTblAddr = ctx.getAddressInDefaultAS(entryTableVA);
 
@@ -215,7 +215,7 @@ public abstract class ILibstub {
 	public void process(ArmElfPrxLoaderContext processingContext, Address libstubAddress) throws Exception {
 		ctx = processingContext;
 		ctx.monitor.checkCancelled();
-		
+
 		// (1) Read the library's name
 		Address libNameAddr = readLibraryName();
 

--- a/src/main/java/vitaloaderredux/scetypes/SELFConstants.java
+++ b/src/main/java/vitaloaderredux/scetypes/SELFConstants.java
@@ -14,7 +14,7 @@ public final class SELFConstants {
 	public static final int SCE_MODULE_ATTR_CAN_RESTART 	= 0x0008;
 	public static final int SCE_MODULE_ATTR_CAN_RELOCATE 	= 0x0010;
 	public static final int SCE_MODULE_ATTR_CANT_SHARE 		= 0x0020;
-	
+
 	//Library attributes (type LIBRARY_ATTRIBUTES)
 	public static final String LIBRARY_ATTR_DATATYPE_NAME = "LIBRARY_ATTRIBUTES";
 	public static final int SCE_LIBRARY_ATTR_NONE 				= 0x0;
@@ -24,7 +24,7 @@ public final class SELFConstants {
 	public static final int SCE_LIBRARY_ATTR_LOOSE_IMPORT 		= 0x8;
 	public static final int SCE_LIBRARY_ATTR_SYSCALL_EXPORT 	= 0x4000;
 	public static final int SCE_LIBRARY_ATTR_MAIN_EXPORT 		= 0x8000;
-	
+
 
 	/**
 	 * Creates the module attributes datatype in the specified DataTypeManager.
@@ -43,7 +43,7 @@ public final class SELFConstants {
 		attr.add("SCE_MODULE_ATTR_CANT_SHARE", SCE_MODULE_ATTR_CANT_SHARE, "?Module cannot be shared?");
 		return attr;
 	}
-	
+
 	/**
 	 * Creates the library attributes datatype in the specified DataTypeManager.
 	 * @param dtm Target program's DataTypeManager
@@ -52,15 +52,15 @@ public final class SELFConstants {
 	 */
 	public static EnumDataType createLibraryAttributesDataType(DataTypeManager dtm, CategoryPath catpath) {
 		EnumDataType dt = new EnumDataType(catpath, LIBRARY_ATTR_DATATYPE_NAME, 2, dtm);
-		
+
 		//Placeholder value when no attributes are present.
 		dt.add("SCE_LIBRARY_ATTR_NONE", SCE_LIBRARY_ATTR_NONE);
-		
+
 		//[EXPORT ONLY] Library is automatically exported
 		//If not present, a call to ExportLibrary must be made after sceKernelLoadStartModule() for the library to be importable by other modules.
 		//(As far as I know, this whole process is never used ?and could only be used from kernel anyways?)
 		dt.add("SCE_LIBRARY_ATTR_AUTO_EXPORT", SCE_LIBRARY_ATTR_AUTO_EXPORT, "Library is automatically exported and visible to other modules");
-		
+
 		//TODO: what this do?
 		dt.add("SCE_LIBRARY_ATTR_WEAK_EXPORT", SCE_LIBRARY_ATTR_WEAK_EXPORT);
 
@@ -81,7 +81,7 @@ public final class SELFConstants {
 		//this library attribute if this behaviour is required.
 		//
 		dt.add("SCE_LIBRARY_ATTR_PLUGIN_LINK_EXPORT", SCE_LIBRARY_ATTR_PLUGIN_LINK_EXPORT, "Library is exported for manual linking by user");
-		
+
 		//[IMPORT ONLY] Library is loosely imported.
 		//During linking of a module, if an imported library is missing, this attribute indicates
 		//the starting process should continue regardless (instead of erroring out). In such a case,
@@ -91,7 +91,7 @@ public final class SELFConstants {
 		//N.B. the main module of all processes is started AS IF all libraries were marked with attribute LOOSE_IMPORT.
 		//N.B. LOOSE_IMPORT libraries don't have NID tables scrambled
 		dt.add("SCE_LIBRARY_ATTR_LOOSE_IMPORT", SCE_LIBRARY_ATTR_LOOSE_IMPORT, "Loosely imported library - module can start even if library isn't found");
-		
+
 		//[EXPORT ONLY] Library is exported to the syscall interface
 		//If a user mode module attempts to link to a kernel mode library, this attribute tells
 		//Modulemgr to register the function as a syscall and write out a SVC thunk in user mode.
@@ -102,16 +102,16 @@ public final class SELFConstants {
 		//causes a kernel panic. On non-debug kernels, Modulemgr will write out the U2U thunk instead which
 		//results in a kernel address leak that can be used for kASLR bypass (but is ultimately useless).
 		dt.add("SCE_LIBRARY_ATTR_SYSCALL_EXPORT", SCE_LIBRARY_ATTR_SYSCALL_EXPORT, "Library is exported to user mode via syscall interface allowed if this flag is present)");
-		
+
 		//[EXPORT ONLY] Library is the module's "Main Export" pseudo-library
 		//This pseudo-library is used to export variables and functions such
 		//as module_start for use by Modulemgr itself instead of other modules.
 		//
 		//Modules can only have a single MAIN_EXPORT library (TODO: is this enforced?)
 		dt.add("SCE_LIBRARY_ATTR_MAIN_EXPORT", SCE_LIBRARY_ATTR_MAIN_EXPORT, "Module main export (NONAME library)");
-		
+
 		return dt;
 	}
 
-	
+
 }

--- a/src/main/java/vitaloaderredux/scetypes/SceKernelLibraryEntryTable_arm.java
+++ b/src/main/java/vitaloaderredux/scetypes/SceKernelLibraryEntryTable_arm.java
@@ -13,16 +13,16 @@ import vitaloaderredux.misc.Utils;
 public class SceKernelLibraryEntryTable_arm extends ILibent {
 	public static final String STRUCTURE_NAME = "sceKernelLibraryEntryTable_arm"; //Technically a typedef... heh.
 	public static final int SIZE = 0x1C;
-	
+
 	@Override
 	protected String _structureName() { return STRUCTURE_NAME; }
-	
+
 	public SceKernelLibraryEntryTable_arm(BinaryReader reader) throws IOException {
 		final int structureSize = reader.readNextByte();
 		if (structureSize != SIZE) {
 			throw new MalformedElfException(String.format("Invalid Libent size! (0x%X != 0x%X)", structureSize, SIZE));
 		}
-		
+
 		auxattribute = reader.readNextByte();
 		version = reader.readNextUnsignedShort();
 		attribute = reader.readNextUnsignedShort();
@@ -33,13 +33,13 @@ public class SceKernelLibraryEntryTable_arm extends ILibent {
 		hashinfotls = reader.readNextByte();
 		reader.readNextByte(); //reserved2
 		nidaltsets = reader.readNextByte();
-		
+
 		libname_nid = ILibent.UNKNOWN_NID; //See SceKernelLibraryStubTable_arm for the rationale.
 		libname = reader.readNextInt();
-		
+
 		nidtable = reader.readNextInt();
 		addtable = reader.readNextInt();
-		
+
 		Utils.assertBRSize(STRUCTURE_NAME, reader, SIZE);
 	}
 
@@ -51,7 +51,7 @@ public class SceKernelLibraryEntryTable_arm extends ILibent {
 			DATATYPE.add(Datatypes.stringptr, "libname", "Pointer to library's name");
 			DATATYPE.add(Datatypes.u32ptr, "nidtable", "Pointer to library's NID table");
 			DATATYPE.add(Datatypes.ptr_to_ptr, "addtable", "Pointer to library's address table");
-			
+
 			Utils.assertStructureSize(DATATYPE, SIZE);
 		}
 		return DATATYPE;

--- a/src/main/java/vitaloaderredux/scetypes/SceKernelLibraryEntryTable_prx2arm.java
+++ b/src/main/java/vitaloaderredux/scetypes/SceKernelLibraryEntryTable_prx2arm.java
@@ -13,16 +13,16 @@ import vitaloaderredux.misc.Utils;
 public class SceKernelLibraryEntryTable_prx2arm extends ILibent {
 	public static final String STRUCTURE_NAME = "sceKernelLibraryEntryTable_prx2arm";
 	public static final int SIZE = 0x20;
-	
+
 	@Override
 	protected String _structureName() { return STRUCTURE_NAME; }
-	
+
 	public SceKernelLibraryEntryTable_prx2arm(BinaryReader reader) throws IOException {
 		final int structureSize = reader.readNextByte();
 		if (structureSize != SIZE) {
 			throw new MalformedElfException(String.format("Invalid Libent size! (0x%X != 0x%X)", structureSize, SIZE));
 		}
-		
+
 		auxattribute = reader.readNextByte();
 		version = reader.readNextUnsignedShort();
 		attribute = reader.readNextUnsignedShort();
@@ -33,10 +33,10 @@ public class SceKernelLibraryEntryTable_prx2arm extends ILibent {
 		hashinfotls = reader.readNextByte();
 		reader.readNextByte(); //reserved2
 		nidaltsets = reader.readNextByte();
-		
+
 		libname_nid = reader.readNextInt();
 		libname = reader.readNextInt();
-		
+
 		nidtable = reader.readNextInt();
 		addtable = reader.readNextInt();
 
@@ -52,7 +52,7 @@ public class SceKernelLibraryEntryTable_prx2arm extends ILibent {
 			DATATYPE.add(Datatypes.stringptr, "libname", "Pointer to library's name");
 			DATATYPE.add(Datatypes.u32ptr, "nidtable", "Pointer to library's NID table");
 			DATATYPE.add(Datatypes.ptr_to_ptr, "addtable", "Pointer to library's address table");
-			
+
 			Utils.assertStructureSize(DATATYPE, SIZE);
 		}
 		return DATATYPE;

--- a/src/main/java/vitaloaderredux/scetypes/SceKernelLibraryStubTable_0x24.java
+++ b/src/main/java/vitaloaderredux/scetypes/SceKernelLibraryStubTable_0x24.java
@@ -13,37 +13,37 @@ import vitaloaderredux.misc.Utils;
 public class SceKernelLibraryStubTable_0x24 extends ILibstub {
 	public static final String STRUCTURE_NAME = "SceLibstub_0x24";
 	public static final int SIZE = 0x24;
-	
+
 	@Override
 	protected String _structureName() { return STRUCTURE_NAME; }
-	
+
 	public SceKernelLibraryStubTable_0x24(BinaryReader reader) throws IOException {
 		final int size = reader.readNextUnsignedByte();
 		if (size != SIZE) {
 			throw new MalformedElfException(String.format("Invalid Libstub size (0x%X != 0x%X)", size, SIZE));
 		}
-		
+
 		reader.readNextUnsignedByte(); //reserved1
-		
-		
-		
+
+
+
 		version = reader.readNextUnsignedShort();
-		
+
 		attribute = reader.readNextUnsignedShort();
-		
+
 		nfunc = reader.readNextUnsignedShort();
 		nvar = reader.readNextUnsignedShort();
 		ntlsvar = reader.readNextUnsignedShort();
-		
+
 		libname_nid = reader.readNextInt();
 		libname = reader.readNextInt();
-		
+
 		func_nidtable = reader.readNextInt();
 		func_table = reader.readNextInt();
-		
+
 		var_nidtable = reader.readNextInt();
 		var_table = reader.readNextInt();
-		
+
 		Utils.assertBRSize(STRUCTURE_NAME, reader, size);
 	}
 
@@ -53,19 +53,19 @@ public class SceKernelLibraryStubTable_0x24 extends ILibstub {
 	public int getTLSVariablesEntryTableAddress() {
 		if (ntlsvar == 0)
 			return 0;
-		
+
 		return var_table + 4 * nvar;
 	}
-	
+
 	@Override
 	public int getTLSVariablesNIDTableAddress() {
 		if (ntlsvar == 0)
 			return 0;
-		
+
 		return var_nidtable + 4 * nvar;
 	}
-	
-	
+
+
 	@Override
 	public DataType toDataType(DataType libraryAttributesType) {
 		if (DATATYPE == null) {
@@ -83,7 +83,7 @@ public class SceKernelLibraryStubTable_0x24 extends ILibstub {
 			DATATYPE.add(Datatypes.ptr_to_ptr, "func_table", "Pointer to functions table");
 			DATATYPE.add(Datatypes.u32ptr, "var_nidtable", "Pointer to variables NID table");
 			DATATYPE.add(Datatypes.ptr_to_ptr, "var_table", "Pointer to variables table");
-			
+
 			Utils.assertStructureSize(DATATYPE, SIZE);
 		}
 		return DATATYPE;

--- a/src/main/java/vitaloaderredux/scetypes/SceKernelLibraryStubTable_arm.java
+++ b/src/main/java/vitaloaderredux/scetypes/SceKernelLibraryStubTable_arm.java
@@ -13,7 +13,7 @@ import vitaloaderredux.misc.Utils;
 public class SceKernelLibraryStubTable_arm extends ILibstub {
 	public static final String STRUCTURE_NAME = "sceKernelLibraryStubTable_arm";
 	public static final int SIZE = 0x2C;
-	
+
 	@Override
 	protected String _structureName() { return STRUCTURE_NAME; }
 
@@ -22,32 +22,32 @@ public class SceKernelLibraryStubTable_arm extends ILibstub {
 		if (structureSize != SIZE) {
 			throw new MalformedElfException(String.format("Invalid Libstub size (0x%X != 0x%X)", structureSize, SIZE));
 		}
-		
+
 		//We could try retrieving the library NID, located at (libraryNameAddress - 0x8).
 		//However, in firmware 0.902 (and 0.920?), there are actually no NIDs stored there.
 		//Since we match libraries based on name (and not NID) anyways,
 		//we don't really care about this, so return UNKNOWN_NID.
 		libname_nid = ILibstub.UNKNOWN_NID;
-		
+
 		version = reader.readNextUnsignedShort();
 		attribute = reader.readNextUnsignedShort();
-		
+
 		nfunc = reader.readNextUnsignedShort();
 		nvar = reader.readNextUnsignedShort();
 		ntlsvar = reader.readNextUnsignedShort();
-		
+
 		reader.readNextInt(); //reserved2
 		libname = reader.readNextInt();
-		
+
 		func_nidtable = reader.readNextInt();
 		func_table = reader.readNextInt();
-		
+
 		var_nidtable = reader.readNextInt();
 		var_table = reader.readNextInt();
-		
+
 		tls_nidtable = reader.readNextInt();
 		tls_table = reader.readNextInt();
-		
+
 		Utils.assertBRSize(STRUCTURE_NAME, reader, SIZE);
 	}
 
@@ -64,7 +64,7 @@ public class SceKernelLibraryStubTable_arm extends ILibstub {
 			DATATYPE.add(Datatypes.ptr_to_ptr, "var_table", "Pointer to variables table");
 			DATATYPE.add(Datatypes.u32ptr, "tls_nidtable", "Pointer to TLS variables NID table");
 			DATATYPE.add(Datatypes.ptr_to_ptr, "tls_table", "Pointer to TLS variables entry table");
-			
+
 			Utils.assertStructureSize(DATATYPE, SIZE);
 		}
 		return DATATYPE;

--- a/src/main/java/vitaloaderredux/scetypes/SceKernelLibraryStubTable_prx2arm.java
+++ b/src/main/java/vitaloaderredux/scetypes/SceKernelLibraryStubTable_prx2arm.java
@@ -13,17 +13,17 @@ import vitaloaderredux.misc.Utils;
 public class SceKernelLibraryStubTable_prx2arm extends ILibstub {
 	public static final String STRUCTURE_NAME = "sceKernelLibraryStubTable_prx2arm";
 	public static final int SIZE = 0x34;
-	
+
 	@Override
 	protected String _structureName() { return STRUCTURE_NAME; }
 
-	
+
 	public SceKernelLibraryStubTable_prx2arm(BinaryReader reader) throws IOException {
 		final int structureSize = reader.readNextUnsignedShort();
 		if (structureSize != SIZE) {
 			throw new MalformedElfException(String.format("Invalid Libstub size (0x%X != 0x%X)", structureSize, SIZE));
 		}
-		
+
 		version = reader.readNextUnsignedShort();
 		attribute = reader.readNextUnsignedShort();
 		nfunc = reader.readNextUnsignedShort();
@@ -39,10 +39,10 @@ public class SceKernelLibraryStubTable_prx2arm extends ILibstub {
 		var_table = reader.readNextInt();
 		tls_nidtable = reader.readNextInt();
 		tls_table = reader.readNextInt();
-		
+
 		Utils.assertBRSize(STRUCTURE_NAME, reader, SIZE);
 	}
-	
+
 //ILibstub
 	@Override
 	public DataType toDataType(DataType libraryAttributesType) {
@@ -58,7 +58,7 @@ public class SceKernelLibraryStubTable_prx2arm extends ILibstub {
 			DATATYPE.add(Datatypes.ptr_to_ptr, "var_table", "Pointer to variables table");
 			DATATYPE.add(Datatypes.u32ptr, "tls_nidtable", "Pointer to TLS variables NID table");
 			DATATYPE.add(Datatypes.ptr_to_ptr, "tls_table", "Pointer to TLS variables entry table");
-			
+
 			Utils.assertStructureSize(DATATYPE, SIZE);
 		}
 		return DATATYPE;

--- a/src/main/java/vitaloaderredux/scetypes/SceModuleInfo.java
+++ b/src/main/java/vitaloaderredux/scetypes/SceModuleInfo.java
@@ -11,16 +11,16 @@ import vitaloaderredux.elf.MalformedElfException;
 import vitaloaderredux.misc.Datatypes;
 
 /**
- * 
+ *
  * @author CreepNT
  *
  *
- * @note For this structure, fields marked "RVA" hold offsets 
+ * @note For this structure, fields marked "RVA" hold offsets
  * in the current segment(?) instead of true virtual addresses.
  */
 public class SceModuleInfo {
 	public static final String STRUCTURE_NAME = "SceModuleInfo";
-	
+
 	public final short attributes;
 	public final short[] version = { 0, 0 };
 	public final String modname;
@@ -31,11 +31,11 @@ public class SceModuleInfo {
 	public final long stub_top; //RVA
 	public final long stub_end; //RVA - libstubs are in [libstub_top; libstub_btm)
 	public final long dbg_fingerprint;
-	
+
 	//Those fields can't be marked as final because they may be left uninitialized...
 	public long start_entry; //RVA - 0xFFFFFFFF if not present!
 	public long stop_entry;  //RVA - 0xFFFFFFFF if not present!
-	
+
 	public long tls_top; //RVA - 0 if not present
 	public long tls_filesz;
 	public long tls_memsz;
@@ -49,8 +49,8 @@ public class SceModuleInfo {
 	//strict = true : check that all characters in the modules name are valid ASCII or NUL
 	public static boolean verifyModuleInfoName(BinaryReader nameReader, boolean strict) throws IOException {
 		byte[] rawName = nameReader.readByteArray(nameReader.getPointerIndex(), 27);
-		int nulCharIndex = -1;		
-		
+		int nulCharIndex = -1;
+
 		for (int i = 0; i < rawName.length; i++) {
 			byte b = rawName[i];
 			if (b == '\0') {
@@ -59,30 +59,30 @@ public class SceModuleInfo {
 					break;
 				}
 			}
-			
+
 			if (strict && b != '\0' && !(0x20 <= b && b <= 0x7E)) {
 				return false;
 			}
 		}
 		return (nulCharIndex == -1) ? false : true;
 	}
-	
+
 	private void assertValidName(BinaryReader r) throws IOException {
 		if (!verifyModuleInfoName(r, false)) {
 			throw new MalformedElfException("Malformed SceModuleInfo (bad name)");
 		}
 	}
-	
-	private TypedefDataType MYTYPE = null;	
+
+	private TypedefDataType MYTYPE = null;
 	public SceModuleInfo(BinaryReader reader) throws IOException {
 		attributes = reader.readNextShort();
 		version[0] = reader.readNextByte();
 		version[1] = reader.readNextByte();
-		
+
 		assertValidName(reader);
 
 		modname = reader.readNextAsciiString(27);
-		
+
 		infover = reader.readNextByte();
 		if (infover == 1) {
 			throw new MalformedElfException("struct _scemoduleinfo1 is not supported by Vita!");
@@ -96,9 +96,9 @@ public class SceModuleInfo {
 		ent_end = reader.readNextUnsignedInt();
 		stub_top = reader.readNextUnsignedInt();
 		stub_end = reader.readNextUnsignedInt();
-		
+
 		dbg_fingerprint = reader.readNextUnsignedInt();
-		
+
 		//Change according to version
 		if (infover > 0 && infover < 6) {
 			//sceModuleInfo1 fields
@@ -108,7 +108,7 @@ public class SceModuleInfo {
 			//sceModuleInfo_arm fields
 			arm_exidx_top = reader.readNextUnsignedInt();
 			arm_exidx_end = reader.readNextUnsignedInt();
-			
+
 			if (infover == 3) { //sceModuleInfo_arm_tls fields
 				tls_top = reader.readNextUnsignedInt();
 				tls_filesz = reader.readNextUnsignedInt();
@@ -126,8 +126,8 @@ public class SceModuleInfo {
 			arm_extab_btm = reader.readNextUnsignedInt();
 		}
 	}
-	
-	private DataType _getCommonDataType(DataType modAttrType) {	
+
+	private DataType _getCommonDataType(DataType modAttrType) {
 		StructureDataType sdt = new StructureDataType(Datatypes.SCE_TYPES_CATPATH, "_scemoduleinfo_common", 0);
 		sdt.add(modAttrType, "modattribute", "Module attributes");
 		sdt.add(Datatypes.makeArray(Datatypes.u8, 2), "modversion", "Module version [major.minor]");
@@ -137,8 +137,8 @@ public class SceModuleInfo {
 
 		return new TypedefDataType(Datatypes.SCE_TYPES_CATPATH, "sceModuleInfo_common", sdt);
 	}
-	
-	public DataType toDataType(DataType moduleAttributesDataType) {		
+
+	public DataType toDataType(DataType moduleAttributesDataType) {
 		if (MYTYPE == null) {
 			String _structureName = null;
 			String _typedefName = null;
@@ -160,12 +160,12 @@ public class SceModuleInfo {
 				_typedefName = "sceModuleInfo_prx2arm";
 				break;
 			}
-			
+
 			//Elf32_Addr replacement, but not exactly the correct type !
 			//But it's as good as we can do...
 			//Maybe we shouldn't use it to not break analysis though :shrug:
 			final DataType IBO32 = IBO32DataType.dataType;
-			
+
 			StructureDataType STRUCTURE = new StructureDataType(Datatypes.SCE_TYPES_CATPATH, _structureName, 0);
 			STRUCTURE.add(_getCommonDataType(moduleAttributesDataType), "c", null);
 			STRUCTURE.add(Datatypes.u32, "resreve", "Reserved");
@@ -173,19 +173,19 @@ public class SceModuleInfo {
 			STRUCTURE.add(IBO32, "ent_end", "Address of library entry table end");
 			STRUCTURE.add(IBO32, "stub_top", "Address of library stub table top");
 			STRUCTURE.add(IBO32, "stub_end", "Address of library stub table end");
-			
-			
+
+
 			//Change according to version
 			if (infover > 0) {
 				STRUCTURE.add(Datatypes.u32, "dbg_fingerprint", "Debug fingerprint (used to locate symbols)");
-				
+
 				if (infover < 6) {
 					STRUCTURE.add(IBO32, "start_entry", "Address of the module_start entrypoint");
 					STRUCTURE.add(IBO32, "stop_entry", "Address of the module_stop entrypoint");
-									
+
 					STRUCTURE.add(IBO32, "arm_exidx_top", "ARM EABI exception index table top");
 					STRUCTURE.add(IBO32, "arm_exidx_end", "ARM EABI exception index table end");
-					
+
 					if (infover == 3) { //sceModuleInfo_arm_tls fields
 						STRUCTURE.add(IBO32, "tls_start", "Address of TLS section top");
 						STRUCTURE.add(Datatypes.u32, "tls_filesz", "Size of the TLS section (in file)");
@@ -203,10 +203,10 @@ public class SceModuleInfo {
 					STRUCTURE.add(IBO32, "arm_extab_end", "ARM EABI exception table end");
 				}
 			}
-			
+
 			MYTYPE = new TypedefDataType(Datatypes.SCE_TYPES_CATPATH, _typedefName, STRUCTURE);
 		}
-		
+
 		return MYTYPE;
 	}
 }

--- a/src/main/java/vitaloaderredux/scetypes/SceModuleThreadParameter.java
+++ b/src/main/java/vitaloaderredux/scetypes/SceModuleThreadParameter.java
@@ -17,28 +17,28 @@ public class SceModuleThreadParameter {
 	static public final int SIZE = 0x14;
 	static public final String STRUCTURE_NAME = "SceModuleThreadParameter";
 	static public final int NUM_PARAMS_FOR_VITA = 4;
-	
+
 	public final int numParams;
 	public final int initPriority;
 	public final int stackSize;
 	public final int attr;
 	public final int cpuAffinityMask;
-	
+
 	private final String entrypointName;
-	
+
 	public SceModuleThreadParameter(BinaryReader reader, String mtpEntrypointName) throws IOException {
 		numParams = reader.readNextInt();
 		if (numParams != NUM_PARAMS_FOR_VITA) {
 			throw new MalformedElfException(String.format("Invalid numParams=%d (!= %d) in SceModuleThreadParameter", numParams, NUM_PARAMS_FOR_VITA));
 		}
-		
+
 		initPriority = reader.readNextInt();
 		stackSize = reader.readNextInt();
 		attr = reader.readNextInt();
 		cpuAffinityMask = reader.readNextInt();
-		
+
 		Utils.assertBRSize(mtpEntrypointName, reader, SIZE);
-		
+
 		entrypointName = mtpEntrypointName;
 	}
 
@@ -51,33 +51,33 @@ public class SceModuleThreadParameter {
 			DATATYPE.add(Datatypes.u32, "stackSize", "Size of the entrypoint thread's stack (in bytes)");
 			DATATYPE.add(Datatypes.u32, "attr", "Thread attributes (unused on Vita)");
 			DATATYPE.add(Datatypes.s32, "cpuAffinityMask", "Affinity mask of the entrypoint thread");
-			
+
 			Utils.assertStructureSize(DATATYPE, SIZE);
 		}
 		return DATATYPE;
 	}
-	
+
 	public void process(ArmElfPrxLoaderContext ctx, Address mtpAddress) throws Exception {
 		ctx.createLabeledDataInNamespace(mtpAddress, ctx.moduleNamespace, "sce_" + entrypointName + "_thread_parameter", toDataType());
 	}
-	
+
 	public void addCommentToEntrypoint(ArmElfPrxLoaderContext ctx, int entrypointVA) throws Exception {
 		final int priority = (initPriority == 0) ? 0x10000100 : initPriority;
 		final int stackSz = (stackSize == 0) ? (256*1024) : stackSize;
 		final int affinityMask = (cpuAffinityMask == 0) ? 0xF : cpuAffinityMask;
-		
+
 		String comment = entrypointName + " thread parameters:\n";
 		comment += "Initial priority: " + Utils.prettifyPriority(priority) + "\n";
 		comment += "Stack size: " + Utils.prettifySize(stackSz) + "\n";
 		comment += "CPU affinity mask: " + Utils.prettifyCpuAffinityMask(affinityMask);
-		
+
 		Address epAddr = ctx.getAddressInDefaultAS(entrypointVA & ~1);
 		Function epFunc = ctx.funcMgr.getFunctionAt(epAddr);
-		
+
 		String oldComment = epFunc.getComment();
 		if (oldComment != null) {
 			comment = oldComment + "\n\n" + comment;
 		}
-		epFunc.setComment(comment);		
+		epFunc.setComment(comment);
 	}
 }

--- a/src/main/java/vitaloaderredux/scetypes/SceProcessParam.java
+++ b/src/main/java/vitaloaderredux/scetypes/SceProcessParam.java
@@ -20,13 +20,13 @@ public class SceProcessParam {
 	public static final String STRUCTURE_NAME = "SceProcessParam";
 	public static final int MAGIC = 0x32505350; //'PSP2' in little-endian
 	public static final int minimal_size = 0x28;
-	
+
 	//TODO: apparently, 0.895 has size 0x20...
 	private static final int MIN_SIZE_FOR_AFFINITY_MASK = 0x2C;
 	private static final int MIN_SIZE_FOR_LIBC_PARAM = 0x30;
 	private static final int MIN_SIZE_FOR_UNK30 = 0x34;
 	public static final int maximal_size = 0x34;
-	
+
 	public final int size;
 	public final int magic;
 	public final int version;
@@ -37,23 +37,23 @@ public class SceProcessParam {
 	public final int pSceUserMainThreadAttribute;
 	public final int pSceProcessName;
 	public final int pSceKernelPreloadModuleInhibit;
-	
-	
+
+
 	public int pSceUserMainThreadCpuAffinityMask = 0;
 	public int pLibcParam = 0; //Not present in 0.93x
 	public int unk30 = 0;	   //Not present in 0.94x
-	
+
 	public SceProcessParam(BinaryReader reader) throws IOException {
 		size = reader.readNextInt();
 		if (size < minimal_size || size > maximal_size) {
 			throw new MalformedElfException(String.format("Invalid SceProcessParam size 0x%X", size));
 		}
-		
+
 		magic = reader.readNextInt();
 		if (magic != MAGIC) {
 			throw new MalformedElfException(String.format("Invalid SceProcessParam magic 0x%X != 0x%X", magic, MAGIC));
 		}
-		
+
 		version = reader.readNextInt();
 		sdkVersion = reader.readNextInt();
 		pSceUserMainThreadName = reader.readNextInt();
@@ -62,7 +62,7 @@ public class SceProcessParam {
 		pSceUserMainThreadAttribute = reader.readNextInt();
 		pSceProcessName = reader.readNextInt();
 		pSceKernelPreloadModuleInhibit = reader.readNextInt();
-		
+
 		if (size >= MIN_SIZE_FOR_AFFINITY_MASK) {
 			pSceUserMainThreadCpuAffinityMask = reader.readNextInt();
 		}
@@ -72,15 +72,15 @@ public class SceProcessParam {
 		if (size >= MIN_SIZE_FOR_UNK30) {
 			unk30 = reader.readNextInt();
 		}
-		
+
 		Utils.assertBRSize(STRUCTURE_NAME, reader, size);
 	}
-	
+
 	private StructureDataType DATATYPE = null;
 	public DataType toDataType() {
 		if (DATATYPE == null) {
 			DataType s32ptr = new Pointer32DataType(Datatypes.s32);
-			
+
 			DATATYPE = new StructureDataType(Datatypes.SCE_TYPES_CATPATH, STRUCTURE_NAME, 0);
 			DATATYPE.add(Datatypes.u32, "size", "Size of this structure");
 			DATATYPE.add(Datatypes.makeArray(Datatypes.char8, 4), "magic", "Structure magic ('PSP2')");
@@ -102,25 +102,25 @@ public class SceProcessParam {
 			if (size >= MIN_SIZE_FOR_UNK30) {
 				DATATYPE.add(Datatypes.u32, "unk30", null);
 			}
-			
+
 			Utils.assertStructureSize(DATATYPE, size);
 		}
 		return DATATYPE;
 	}
-	
+
 	private void processLibcParam(ArmElfPrxLoaderContext ctx) throws Exception {
 		if (size < MIN_SIZE_FOR_LIBC_PARAM)
 			return;
-		
+
 		if (pLibcParam == 0) {
 			ctx.logger.appendMsg("No SceLibcParam found in SceProcessParam.");
 			return;
 		}
-		
+
 		Address paramAddr = ctx.getAddressInDefaultAS(pLibcParam);
 		BinaryReader reader = ctx.getBinaryReader(paramAddr);
-		
-		
+
+
 		DataType paramDt = null;
 		final int libcParamSize = reader.peekNextInt();
 		switch(libcParamSize) {
@@ -130,22 +130,22 @@ public class SceProcessParam {
 			libcParam.process(ctx);
 			break;
 		}
-		
+
 		case 0x28:
 			ctx.logf("Skipped SceLibcParam with size 0x%X (structure not reversed yet)", libcParamSize);
-		
+
 		default:
 			ctx.logf("Parsing of SceLibcParam with unsupported size 0x%X skipped", libcParamSize);
 			return;
 		}
-		
+
 		ctx.createLabeledDataInNamespace(paramAddr, ctx.moduleNamespace, "__sce_libcparam", paramDt);
-		
+
 	}
-	
+
 	public void process(ArmElfPrxLoaderContext ctx, Address processParamAddress) throws Exception {
 		ctx.createLabeledDataInNamespace(processParamAddress, ctx.moduleNamespace, "__sce_process_param", toDataType());
-		
+
 		ctx.markupString(pSceUserMainThreadName, "sceUserMainThreadName");
 		Data priority = ctx.markupU32(pSceUserMainThreadPriority, "sceUserMainThreadPriority");
 		Data stackSize = ctx.markupU32(pSceUserMainThreadStackSize, "sceUserMainThreadStackSize");
@@ -153,19 +153,19 @@ public class SceProcessParam {
 		ctx.markupString(pSceProcessName, "sceProcessName");
 		Data inhibit = ctx.markupU32(pSceKernelPreloadModuleInhibit, "sceKernelPreloadModuleInhibit");
 		ctx.markupS32(pSceUserMainThreadCpuAffinityMask, "sceUserMainThreadCpuAffinityMask");
-		
+
 		if (priority != null) {
 			priority.setComment(CodeUnit.PLATE_COMMENT, Utils.prettifyPriority(priority.getInt(0)));
 		}
-		
+
 		if (stackSize != null) {
 			stackSize.setComment(CodeUnit.PLATE_COMMENT, Utils.prettifySize(stackSize.getInt(0)));
 		}
-		
+
 		if (inhibit != null) {
 			inhibit.setComment(CodeUnit.PLATE_COMMENT, Utils.prettifyInhibitBitflag(inhibit.getInt(0)));
 		}
-		
+
 		processLibcParam(ctx);
 	}
 }

--- a/src/main/java/vitaloaderredux/scetypes/libc/LibcxxAllocReplacement.java
+++ b/src/main/java/vitaloaderredux/scetypes/libc/LibcxxAllocReplacement.java
@@ -21,7 +21,7 @@ public class LibcxxAllocReplacement {
 	static public final int SIZE = 0x28;
 	public static final String STRUCTURE_NAME = "SceLibstdcxxAllocReplacement";
 	static public final CategoryPath LIBCXX_ALLOC_REPLACE_CATPATH = new CategoryPath(Datatypes.SCE_LIBC_TYPES_CATPATH, "libcxxallocreplace");
-	
+
 	public final int unk4;
 	public final int user_new;
 	public final int user_new_nothrow;
@@ -31,13 +31,13 @@ public class LibcxxAllocReplacement {
 	public final int user_delete_nothrow;
 	public final int user_delete_array;
 	public final int user_delete_array_nothrow;
-	
+
 	public LibcxxAllocReplacement(BinaryReader reader) throws IOException {
 		final int size = reader.readNextInt();
 		if (size != SIZE) {
 			throw new MalformedElfException(String.format("Invalid LibcAllocReplacement size (0x%X != 0x%X)", size, SIZE));
 		}
-		
+
 		unk4 = reader.readNextInt();
 		user_new = reader.readNextInt();
 		user_new_nothrow = reader.readNextInt();
@@ -47,30 +47,30 @@ public class LibcxxAllocReplacement {
 		user_delete_nothrow = reader.readNextInt();
 		user_delete_array = reader.readNextInt();
 		user_delete_array_nothrow = reader.readNextInt();
-		
+
 		Utils.assertBRSize(STRUCTURE_NAME, reader, size);
 	}
-	
+
 	private FunctionDefinitionDataType
 	F_user_new , F_user_new_nothrow, F_user_new_array, F_user_new_array_nothrow,
 	F_user_delete, F_user_delete_nothrow, F_user_delete_array, F_user_delete_array_nothrow;
-	
+
 	@SafeVarargs
 	private FunctionDefinitionDataType func(DataType returnType, String name, Map.Entry<DataType, String>... args) {
 		return Datatypes.createFunctionDT(LIBCXX_ALLOC_REPLACE_CATPATH, returnType, name, args);
 	}
-	
+
 	private void __create_funcdef_dt() {
 		if (F_user_new == null) {
 			final DataType VOID = VoidDataType.dataType;
 			final DataType size_t = new TypedefDataType("size_t", Datatypes.u32);
 			final StructureDataType std_throw = new StructureDataType(Datatypes.SCE_LIBC_TYPES_CATPATH, "std_throw_t", 0);
 			std_throw.setDescription("C++ std::throw_t (dummy class)");
-			
+
 			//Using void* instead of Pointer32DataType results in better decompilation.
 			final DataType pVoid = new Pointer32DataType(VOID);
 			final DataType throwRef = new Pointer32DataType(std_throw);
-			
+
 			//Create function signatures
 			F_user_new 					= func(pVoid, "user_new", Map.entry(size_t, "count"));
 			F_user_new_nothrow 			= func(pVoid, "user_new_nothrow", Map.entry(size_t, "count"), Map.entry(throwRef, "tag"));
@@ -82,7 +82,7 @@ public class LibcxxAllocReplacement {
 			F_user_delete_array_nothrow = func(VOID, "user_delete_array_nothrow", Map.entry(pVoid, "ptr"), Map.entry(throwRef, "tag"));
 		}
 	}
-	
+
 	public DataType toDataType() {
 		__create_funcdef_dt();
 		StructureDataType dt = new StructureDataType(Datatypes.SCE_LIBC_TYPES_CATPATH, STRUCTURE_NAME, 0);
@@ -96,25 +96,25 @@ public class LibcxxAllocReplacement {
 		dt.add(new Pointer32DataType(F_user_delete_nothrow), "user_delete_nothrow", "'operator delete(void*, const std::nothrow_t&) throw()' replacement");
 		dt.add(new Pointer32DataType(F_user_delete_array), "user_delete_array", "'operator delete[](void*) throw()' replacement");
 		dt.add(new Pointer32DataType(F_user_delete_array_nothrow), "user_delete_array_nothrow", "'operator delete[](void*, const std::nothrow_t&) throw()' replacement");
-		
-		Utils.assertStructureSize(dt, SIZE);		
+
+		Utils.assertStructureSize(dt, SIZE);
 		return dt;
 	}
-	
+
 	private interface MarkupIF {
 		void markup(int va, String name, FunctionDefinitionDataType sig) throws Exception;
 	}
-	
+
 	public void process(ArmElfPrxLoaderContext ctx) throws Exception {
 		__create_funcdef_dt();
-		
+
 		MarkupIF mif = (va, name, sig) -> {
 			if (va != 0) {
 				Function f = ctx.markupFunction(name, va, "libcxx memory allocation replacement function: " + name);
 				ctx.setFunctionSignature(f, sig);
 			}
 		};
-		
+
 		//Markup functions
 		mif.markup(user_new, "user_new", F_user_new);
 		mif.markup(user_new_nothrow, "user_new_nothrow", F_user_new_nothrow);

--- a/src/main/java/vitaloaderredux/scetypes/libc/SceLibcParam_0x38.java
+++ b/src/main/java/vitaloaderredux/scetypes/libc/SceLibcParam_0x38.java
@@ -14,7 +14,7 @@ import vitaloaderredux.misc.Utils;
 public class SceLibcParam_0x38 {
 	public static final String STRUCTURE_NAME = "SceLibcParam";
 	public static final int SIZE = 0x38;
-	
+
 	public final int unk04;
 	public final int pHeapSize;
 	public final int pHeapDefaultSize;
@@ -28,13 +28,13 @@ public class SceLibcParam_0x38 {
 	public final int pHeapUnitSize1MiB;
 	public final int pHeapDetectOverrun;
 	public final int __sce_libc_tls_alloc_replace;
-	
+
 	public SceLibcParam_0x38(BinaryReader reader) throws IOException {
 		final int size = reader.readNextInt();
 		if (size != SIZE) {
 			throw new MalformedElfException(String.format("Invalid SceLibcParam size (0x%X != 0x%X)", size, SIZE));
 		}
-		
+
 		unk04 = reader.readNextInt();
 		pHeapSize = reader.readNextInt();
 		pHeapDefaultSize = reader.readNextInt();
@@ -48,16 +48,16 @@ public class SceLibcParam_0x38 {
 		pHeapUnitSize1MiB = reader.readNextInt();
 		pHeapDetectOverrun = reader.readNextInt();
 		__sce_libc_tls_alloc_replace = reader.readNextInt();
-		
+
 		Utils.assertBRSize(STRUCTURE_NAME, reader, size);
 	}
-	
-	
+
+
 	public DataType toDataType() {
 		final DataType u32 = Datatypes.u32;
 		final DataType ptr = Datatypes.ptr;
 		final DataType u32ptr = Datatypes.u32ptr;
-		
+
 		StructureDataType dt = new StructureDataType(Datatypes.SCE_LIBC_TYPES_CATPATH, "SceLibcParam", 0);
 		dt.add(u32, "size", "Size of this structure");
 		dt.add(u32, "unk04", null);
@@ -67,18 +67,18 @@ public class SceLibcParam_0x38 {
 		dt.add(u32ptr, "pHeapDelayedAlloc", "Pointer to the 'Delay heap allocation' variable - heap memory block allocation is done on first call to *alloc instead of process creation if value pointed to is non-0");
 		dt.add(u32, "sdkVersion", "Version of the SDK used to build this application");
 		dt.add(u32, "unk1C", null);
-		dt.add(ptr, "__sce_libc_alloc_replace", "Pointer to replacement functions for Libc memory allocation functions");		
+		dt.add(ptr, "__sce_libc_alloc_replace", "Pointer to replacement functions for Libc memory allocation functions");
 		dt.add(ptr, "__sce_libcxx_alloc_replace","Pointer to replacement functions for Libcxx (C++) memory allocation functions");
 		dt.add(u32ptr, "pHeapInitialSize", "Pointer to the 'Initial heap allocation size' variable - specifies the size of the memory block to allocate on process creation if dynamic heap is enabled");
 		dt.add(u32ptr, "pHeapUnitSize1MiB", "Pointer to the 'Big heap block granularity' variable - memory block allocations have a 1MiB granularity if value pointed to is non-0 (default is 64KiB)");
 		dt.add(u32ptr, "pHeapDetectOverrun", "Pointer to the 'Detect heap overruns' variable - enables heap checking on free/realloc if value pointed to is non-0");
 		dt.add(ptr, "__sce_libc_tls_alloc_replace", "Pointer to replacement functions for TLS memory allocation functions");
-	
+
 		Utils.assertStructureSize(dt, SIZE);
 		return dt;
 	}
 
-	
+
 	public void process(ArmElfPrxLoaderContext ctx) throws Exception {
 		ctx.markupU32(pHeapSize, "sceLibcHeapSize");
 		ctx.markupU32(pHeapDefaultSize, "__sceLibcHeapSizeDefault");
@@ -87,12 +87,12 @@ public class SceLibcParam_0x38 {
 		ctx.markupU32(pHeapInitialSize, "sceLibcHeapInitialSize");
 		ctx.markupU32(pHeapUnitSize1MiB, "sceLibcHeapUnitSize1MiB");
 		ctx.markupU32(pHeapDetectOverrun, "sceLibcHeapDetectOverrun");
-		
+
 		if (__sce_libc_alloc_replace != 0L) {
 			Address libcReplaceAddr = ctx.getAddressInDefaultAS(__sce_libc_alloc_replace);
 			BinaryReader reader = ctx.getBinaryReader(libcReplaceAddr);
 			int libcReplaceSize = reader.peekNextInt();
-			
+
 			if (libcReplaceSize != LibcAllocReplacement.SIZE) {
 				ctx.logf("Skipped processing of LibcAllocReplacement with unexpected size 0x%X", libcReplaceSize);
 			} else {
@@ -101,13 +101,13 @@ public class SceLibcParam_0x38 {
 				replacement.process(ctx);
 			}
 		}
-		
-		
+
+
 		if (__sce_libcxx_alloc_replace != 0L) {
 			Address libcxxReplaceAddr = ctx.getAddressInDefaultAS(__sce_libcxx_alloc_replace);
 			BinaryReader reader = ctx.getBinaryReader(libcxxReplaceAddr);
 			int libcxxReplaceSize = reader.peekNextInt();
-			
+
 			if (libcxxReplaceSize != LibcxxAllocReplacement.SIZE) {
 				ctx.logf("Skipped processing of LibcxxAllocReplacement with unexpected size 0x%X", libcxxReplaceSize);
 			} else {
@@ -116,13 +116,13 @@ public class SceLibcParam_0x38 {
 				replacement.process(ctx);
 			}
 		}
-		
-		
+
+
 		if (__sce_libc_tls_alloc_replace != 0L) {
 			Address tlsReplaceAddr = ctx.getAddressInDefaultAS(__sce_libc_tls_alloc_replace);
 			BinaryReader reader = ctx.getBinaryReader(tlsReplaceAddr);
 			int tlsReplaceSize = reader.peekNextInt();
-			
+
 			if (tlsReplaceSize != TlsAllocReplacement.SIZE) {
 				ctx.logf("Skipped processing of TlsAllocReplacement with unexpected size 0x%X", tlsReplaceSize);
 			} else {

--- a/src/main/java/vitaloaderredux/scetypes/libc/TlsAllocReplacement.java
+++ b/src/main/java/vitaloaderredux/scetypes/libc/TlsAllocReplacement.java
@@ -21,45 +21,45 @@ public class TlsAllocReplacement {
 	static public final int SIZE = 0x18;
 	public static final String STRUCTURE_NAME = "SceTlsAllocReplacement";
 	static public final CategoryPath TLS_ALLOC_REPLACE_CATPATH = new CategoryPath(Datatypes.SCE_LIBC_TYPES_CATPATH, "tlsreplace");
-	
+
 	public final int unk4;
 	public final int user_malloc_for_tls_init;
 	public final int user_malloc_for_tls_finalize;
 	public final int user_malloc_for_tls;
 	public final int user_free_for_tls;
-	
+
 	public TlsAllocReplacement(BinaryReader reader) throws IOException {
 		final int size = reader.readNextInt();
 		if (size != SIZE) {
 			throw new MalformedElfException(String.format("Invalid TlsAllocReplacement size (0x%X != 0x%X)", size, SIZE));
 		}
-		
+
 		unk4 = reader.readNextInt();
 		user_malloc_for_tls_init = reader.readNextInt();
 		user_malloc_for_tls_finalize = reader.readNextInt();
 		user_malloc_for_tls = reader.readNextInt();
 		user_free_for_tls = reader.readNextInt();
-		
+
 		Utils.assertBRSize(STRUCTURE_NAME, reader, size);
 	}
-	
+
 	private FunctionDefinitionDataType
 		F_user_malloc_for_tls_init, F_user_malloc_for_tls_finalize,
 		F_user_malloc_for_tls, F_user_free_for_tls;
-	
+
 	@SafeVarargs
 	private FunctionDefinitionDataType func(DataType returnType, String name, Map.Entry<DataType, String>... args) {
 		return Datatypes.createFunctionDT(TLS_ALLOC_REPLACE_CATPATH, returnType, name, args);
 	}
-	
+
 	private void __create_funcdef_dt() {
 		if (F_user_malloc_for_tls_init == null) {
 			final DataType VOID = VoidDataType.dataType;
 			final DataType size_t = new TypedefDataType("size_t", Datatypes.u32);
-			
+
 			//Using void* instead of Pointer32DataType results in better decompilation.
 			final DataType pVoid = new Pointer32DataType(VOID);
-			
+
 			//Create function signatures
 			F_user_malloc_for_tls_init 		= func(VOID, "user_malloc_for_tls_init");
 			F_user_malloc_for_tls_finalize 	= func(VOID, "user_malloc_for_tls_finalize");
@@ -67,7 +67,7 @@ public class TlsAllocReplacement {
 			F_user_free_for_tls 			= func(VOID, "user_free_for_tls", Map.entry(pVoid, "ptr"));
 		}
 	}
-	
+
 	public DataType toDataType() {
 		__create_funcdef_dt();
 		StructureDataType dt = new StructureDataType(Datatypes.SCE_LIBC_TYPES_CATPATH, STRUCTURE_NAME, 0);
@@ -77,28 +77,28 @@ public class TlsAllocReplacement {
 		dt.add(new Pointer32DataType(F_user_malloc_for_tls_finalize), "user_malloc_for_tls_finalize", "Finalization function for TLS alloc replacement");
 		dt.add(new Pointer32DataType(F_user_malloc_for_tls), "user_malloc_for_tls", "malloc_for_tls() replacement");
 		dt.add(new Pointer32DataType(F_user_free_for_tls), "user_free_for_tls", "free_for_tls() replacement");
-		
+
 		if (dt.getLength() != SIZE)
 			System.err.println("Unexpected " + STRUCTURE_NAME + " data type size (" + dt.getLength() + " != expected " + SIZE + " !)");
-		
+
 		Utils.assertStructureSize(dt, SIZE);
 		return dt;
 	}
-	
+
 	private interface MarkupIF {
 		void markup(int va, String name, FunctionDefinitionDataType sig) throws Exception;
 	}
-	
+
 	public void process(ArmElfPrxLoaderContext ctx) throws Exception {
 		__create_funcdef_dt();
-		
+
 		MarkupIF mif = (va, name, sig) -> {
 			if (va != 0) {
 				Function f = ctx.markupFunction(name, va, "TLS memory allocation replacement function: " + name);
 				ctx.setFunctionSignature(f, sig);
 			}
 		};
-		
+
 		mif.markup(user_malloc_for_tls_init, "user_malloc_for_tls_init", F_user_malloc_for_tls_init);
 		mif.markup(user_malloc_for_tls_finalize, "user_malloc_for_tls_finalize", F_user_malloc_for_tls_finalize);
 		mif.markup(user_malloc_for_tls, "user_malloc_for_tls", F_user_malloc_for_tls);


### PR DESCRIPTION
Modify the NIDAnalyzer to support loading a folder full of NID `.yaml` files (e.g., the `db` folder of `vitasdk/vita-headers`), in addition to a single YAML file.

Fixes #7
