### PR TITLE
misc/Utils: handle CPU_MASK_2 properly

### DIFF
--- a/src/main/java/vitaloaderredux/misc/Utils.java
+++ b/src/main/java/vitaloaderredux/misc/Utils.java
@@ -110,13 +110,6 @@ public class Utils {
 			result += "SCE_KERNEL_CPU_MASK_" + userSuffix + "2";
 		}
 
-		if ((affinityMask & 0x4) != 0) {
-			if (num_bits != 0)
-				result += " | ";
-			num_bits++;
-			result += "SCE_KERNEL_CPU_MASK_" + userSuffix + "2";
-		}
-
 		if ((affinityMask & 0x2) != 0) {
 			if (num_bits != 0)
 				result += " | ";


### PR DESCRIPTION
SCE_KERNEL_CPU_MASK_2 would be printed twice... let's avoid that