### PR TITLE
workflows: update build matrix

### DIFF
--- a/.github/workflows/build_extension.yml
+++ b/.github/workflows/build_extension.yml
@@ -13,13 +13,10 @@ jobs:
     strategy:
       matrix:
         ghidra:
+          - "11.4"
           - "11.3.2"
-          - "11.3.1"
           - "11.2"
-          - "11.1.2"
-          - "11.0.3"
           - "10.4"
-          - "10.3.3"
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Remove certain unused versions to avoid wasting Actions time, and add 11.4 to build matrix.